### PR TITLE
[Feat] 캘린더 뷰 구현

### DIFF
--- a/Lovechive/Lovechive.xcodeproj/project.pbxproj
+++ b/Lovechive/Lovechive.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AA14DE0C2D7DA02600664CE5 /* RxDataSources in Frameworks */ = {isa = PBXBuildFile; productRef = AA14DE0B2D7DA02600664CE5 /* RxDataSources */; };
+		AA14E3B92D8000F600664CE5 /* FSCalendar in Frameworks */ = {isa = PBXBuildFile; productRef = AA14E3B82D8000F600664CE5 /* FSCalendar */; };
 		AAA080A82D797A2B0025DE23 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = AAA080A72D797A2B0025DE23 /* FirebaseAnalytics */; };
 		AAA080AA2D797A2B0025DE23 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = AAA080A92D797A2B0025DE23 /* FirebaseAuth */; };
 		AAA080AC2D797A2B0025DE23 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = AAA080AB2D797A2B0025DE23 /* FirebaseCrashlytics */; };
@@ -88,6 +89,7 @@
 				AAA080A82D797A2B0025DE23 /* FirebaseAnalytics in Frameworks */,
 				AAB858FD2D786879000AEBB2 /* RxKeyboard in Frameworks */,
 				AAA080AE2D797A2B0025DE23 /* FirebaseFirestore in Frameworks */,
+				AA14E3B92D8000F600664CE5 /* FSCalendar in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -158,6 +160,7 @@
 				AAA080AF2D797A2B0025DE23 /* FirebaseMessaging */,
 				AAA080B12D797A2B0025DE23 /* FirebaseStorage */,
 				AA14DE0B2D7DA02600664CE5 /* RxDataSources */,
+				AA14E3B82D8000F600664CE5 /* FSCalendar */,
 			);
 			productName = Lovechive;
 			productReference = AAB858C32D786771000AEBB2 /* Lovechive.app */;
@@ -248,6 +251,7 @@
 				AAB858FE2D786883000AEBB2 /* XCRemoteSwiftPackageReference "RxSwift" */,
 				AAA080A62D797A2B0025DE23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 				AA14DE0A2D7DA02600664CE5 /* XCRemoteSwiftPackageReference "RxDataSources" */,
+				AA14E3B72D8000F600664CE5 /* XCRemoteSwiftPackageReference "FSCalendar" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = AAB858C42D786771000AEBB2 /* Products */;
@@ -632,6 +636,14 @@
 				minimumVersion = 5.0.2;
 			};
 		};
+		AA14E3B72D8000F600664CE5 /* XCRemoteSwiftPackageReference "FSCalendar" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/WenchaoD/FSCalendar";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.8.4;
+			};
+		};
 		AAA080A62D797A2B0025DE23 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -671,6 +683,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA14DE0A2D7DA02600664CE5 /* XCRemoteSwiftPackageReference "RxDataSources" */;
 			productName = RxDataSources;
+		};
+		AA14E3B82D8000F600664CE5 /* FSCalendar */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = AA14E3B72D8000F600664CE5 /* XCRemoteSwiftPackageReference "FSCalendar" */;
+			productName = FSCalendar;
 		};
 		AAA080A72D797A2B0025DE23 /* FirebaseAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Lovechive/Lovechive.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Lovechive/Lovechive.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bcd4767f1b3b26c600d007d9a8bbfbbb6f5fcc3e615faef87360d5202d4e5273",
+  "originHash" : "bb08142e27c84ea6027ee2ac3218069898c39b2b165d27bacb8bae3b1b0fa4cb",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "eb523407e4293568ed55590728205c359cbecc5b",
         "version" : "11.9.0"
+      }
+    },
+    {
+      "identity" : "fscalendar",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/WenchaoD/FSCalendar",
+      "state" : {
+        "revision" : "0fbdec5172fccb90f707472eeaea4ffe095278f6",
+        "version" : "2.8.4"
       }
     },
     {

--- a/Lovechive/Lovechive/Source/AppHelpers/AppConfig/AppConfig.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/AppConfig/AppConfig.swift
@@ -63,4 +63,15 @@ enum AppConfig {
         static let info: String = "아직 일정이 추가되지 않았어요"
         static let cellId: String = "PlanViewCell"
     }
+    
+    // MARK: - CalendarView에서 사용할 String 데이터
+    
+    enum CalendarViewConfig {
+        static let cellId: String = "ScheduleViewCell"
+        static let headerDate: String = "2000년 1월"
+        static let cellDate: String = "오전 0시"
+        static let cellTitle: String = "새로운 일정"
+        static let title: String = "1월 1일 일정"
+        static let info: String = "아직 일정이 없습니다."
+    }
 }

--- a/Lovechive/Lovechive/Source/AppHelpers/AppHelp/AlertManager.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/AppHelp/AlertManager.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import RxSwift
 
 /**
  프로젝트 전역에서 사용할 Alert 객체
@@ -24,7 +25,6 @@ struct AlertManager {
     var cancelTitle: String
     var activeTitle: String?
     var destructiveTitle: String?
-    let completion: (() -> Void)?
     
     // 가장 기본적인 형태의 Alert
     // cancel 버튼만 보유
@@ -38,7 +38,6 @@ struct AlertManager {
         self.cancelTitle = cancelTitle
         self.activeTitle = nil
         self.destructiveTitle = nil
-        self.completion = nil
     }
     
     // 2개의 선택지를 제공하는 Alert
@@ -47,14 +46,12 @@ struct AlertManager {
     init(title: String,
          message: String,
          cancelTitle: String,
-         activeTitle: String?,
-         completion: (() -> Void)?
+         activeTitle: String?
     ) {
         self.title = title
         self.message = message
         self.cancelTitle = cancelTitle
         self.activeTitle = activeTitle
-        self.completion = completion
         self.destructiveTitle = nil
     }
     
@@ -64,14 +61,12 @@ struct AlertManager {
     init(title: String,
          message: String,
          cancelTitle: String,
-         destructiveTitle: String?,
-         completion: (() -> Void)?
+         destructiveTitle: String?
     ) {
         self.title = title
         self.message = message
         self.cancelTitle = cancelTitle
         self.destructiveTitle = destructiveTitle
-        self.completion = completion
         self.activeTitle = nil
     }
     
@@ -79,22 +74,37 @@ struct AlertManager {
     /// - Parameters:
     ///   - view: Alert을 present 할 뷰 컨트롤러
     ///   - style: AlertViewController Style
-    func showAlert(_ style: UIAlertController.Style) {
-        guard let view = AppHelpers.getTopViewController() else { return }
-        let alert = UIAlertController(title: self.title, message: self.message, preferredStyle: style)
-        alert.addAction(UIAlertAction(title: self.cancelTitle, style: .cancel))
-        
-        if let activeTitle {
-            alert.addAction(UIAlertAction(title: activeTitle, style: .default) { [weak view] _ in
-                completion?()
+    func showAlert(_ style: UIAlertController.Style) -> Observable<Bool> {
+        return Observable.create { observer in
+            guard let view = AppHelpers.getTopViewController() else { return Disposables.create() }
+            
+            let alert = UIAlertController(title: self.title, message: self.message, preferredStyle: style)
+            
+            alert.addAction(UIAlertAction(title: self.cancelTitle, style: .cancel) { _ in
+                observer.onNext(false)
+                observer.onCompleted()
             })
-        } else if let destructiveTitle {
-            alert.addAction(UIAlertAction(title: destructiveTitle, style: .destructive) { [weak view] _ in
-                completion?()
-            })
+            
+            if let activeTitle {
+                alert.addAction(UIAlertAction(title: activeTitle, style: .default) { [weak view] _ in
+                    observer.onNext(true)
+                    observer.onCompleted()
+                })
+            } else if let destructiveTitle {
+                alert.addAction(UIAlertAction(title: destructiveTitle, style: .destructive) { [weak view] _ in
+                    observer.onNext(true)
+                    observer.onCompleted()
+                })
+            }
+            
+            DispatchQueue.main.async {
+                view.present(alert, animated: true)
+            }
+            
+            return Disposables.create {
+                alert.dismiss(animated: true)
+            }
         }
-        
-        view.present(alert, animated: true)
     }
     
 }

--- a/Lovechive/Lovechive/Source/AppHelpers/AppHelp/HapticDrawer.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/AppHelp/HapticDrawer.swift
@@ -7,7 +7,8 @@
 
 import UIKit
 
-enum HapticManager {
+/// 프로젝트 내에서 햅틱 피드백을 사용할 때 사용할 전역 메소드를 담아두는 스페이스
+enum HapticDrawer {
     
     static func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
         let generator = UINotificationFeedbackGenerator()

--- a/Lovechive/Lovechive/Source/AppHelpers/AppHelp/HapticManager.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/AppHelp/HapticManager.swift
@@ -1,0 +1,30 @@
+//
+//  HapticManager.swift
+//  TripLog
+//
+//  Created by 장상경 on 2/18/25.
+//
+
+import UIKit
+
+enum HapticManager {
+    
+    static func notification(type: UINotificationFeedbackGenerator.FeedbackType) {
+        let generator = UINotificationFeedbackGenerator()
+        generator.prepare()
+        generator.notificationOccurred(type)
+    }
+    
+    static func impact(style: UIImpactFeedbackGenerator.FeedbackStyle, view: UIView) {
+        if #available(iOS 17.5, *) {
+            let generator = UIImpactFeedbackGenerator(style: style, view: view)
+            generator.prepare()
+            generator.impactOccurred()
+        } else {
+            // Fallback on earlier versions
+            let generator = UIImpactFeedbackGenerator(style: style)
+            generator.prepare()
+            generator.impactOccurred()
+        }
+    }
+}

--- a/Lovechive/Lovechive/Source/AppHelpers/Extension/Date+Extension.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/Extension/Date+Extension.swift
@@ -53,4 +53,12 @@ extension Date {
         return formatter.string(from: self)
     }
     
+    func formattedDateToString() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일 a h시 m분"
+        
+        return formatter.string(from: self)
+    }
+    
 }

--- a/Lovechive/Lovechive/Source/AppHelpers/Extension/Date+Extension.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/Extension/Date+Extension.swift
@@ -29,4 +29,28 @@ extension Date {
         return formatter.string(from: self)
     }
     
+    func formattedDateToYM() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월"
+        
+        return formatter.string(from: self)
+    }
+    
+    func formattedDateToSchedule() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "M월 d일 일정"
+        
+        return formatter.string(from: self)
+    }
+    
+    func formattedDateToScheduleTime() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "a h시 m분"
+        
+        return formatter.string(from: self)
+    }
+    
 }

--- a/Lovechive/Lovechive/Source/AppHelpers/Extension/Date+Extension.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/Extension/Date+Extension.swift
@@ -9,6 +9,7 @@ import Foundation
 
 extension Date {
     
+    /// Date 타입의 formtter 타입 정의
     enum DateFormatType {
         case yearMonthDay
         case yearMonthDayHourMinute

--- a/Lovechive/Lovechive/Source/AppHelpers/Extension/Date+Extension.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/Extension/Date+Extension.swift
@@ -9,54 +9,39 @@ import Foundation
 
 extension Date {
     
-    /// Date를 String 타입으로 변환시키는 메소드
-    /// - Returns: String 타입의 날짜
-    func formattedDate() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy년 M월 d일"
+    enum DateFormatType {
+        case yearMonthDay
+        case yearMonthDayHourMinute
+        case yearMonth
+        case monthDay
+        case hourMinute
+        case fullTime
         
-        return formatter.string(from: self)
+        var dateFormat: String {
+            switch self {
+            case .yearMonthDay:
+                return "yyyy년 M월 d일"
+            case .yearMonthDayHourMinute:
+                return "yyyy.M.d(E) a h시 m분"
+            case .yearMonth:
+                return "yyyy년 M월"
+            case .monthDay:
+                return "M월 d일 일정"
+            case .hourMinute:
+                return "a h시 m분"
+            case .fullTime:
+                return "yyyy년 M월 d일 a h시 m분"
+            }
+        }
     }
     
-    /// Date를 String 타입으로 변환시키는 메소드
-    /// - Returns: String 타입의 날짜, 시간
-    func formattedDateAndTime() -> String {
+    /// Date 타입의 데이터를 String 타입으로 변환시키는 메소드
+    /// - Parameter type: 변경시킬 Date 타입
+    /// - Returns: 변환된 String 타입
+    func formattedDateToString(_ type: DateFormatType) -> String {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy.M.d(E) a h시 m분"
-        
-        return formatter.string(from: self)
-    }
-    
-    func formattedDateToYM() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy년 M월"
-        
-        return formatter.string(from: self)
-    }
-    
-    func formattedDateToSchedule() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "M월 d일 일정"
-        
-        return formatter.string(from: self)
-    }
-    
-    func formattedDateToScheduleTime() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "a h시 m분"
-        
-        return formatter.string(from: self)
-    }
-    
-    func formattedDateToString() -> String {
-        let formatter = DateFormatter()
-        formatter.locale = Locale(identifier: "ko_KR")
-        formatter.dateFormat = "yyyy년 M월 d일 a h시 m분"
+        formatter.dateFormat = type.dateFormat
         
         return formatter.string(from: self)
     }

--- a/Lovechive/Lovechive/Source/AppHelpers/Extension/String+Extension.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/Extension/String+Extension.swift
@@ -1,0 +1,20 @@
+//
+//  String+Extension.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/13/25.
+//
+
+import Foundation
+
+extension String {
+    
+    func formattedStringToDate() -> Date? {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "ko_KR")
+        formatter.dateFormat = "yyyy년 M월 d일 a h시 m분"
+        
+        return formatter.date(from: self)
+    }
+    
+}

--- a/Lovechive/Lovechive/Source/AppHelpers/Extension/String+Extension.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/Extension/String+Extension.swift
@@ -9,6 +9,8 @@ import Foundation
 
 extension String {
     
+    /// String 타입의 데이터를 Date 타입으로 변환하는 메소드
+    /// - Returns: Date 타입으로 변환 된 데이터(nil일 수도 있음)
     func formattedStringToDate() -> Date? {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "ko_KR")

--- a/Lovechive/Lovechive/Source/AppHelpers/Extension/UITextField+Extension.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/Extension/UITextField+Extension.swift
@@ -1,0 +1,24 @@
+//
+//  UITextField+Extension.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import UIKit
+
+extension UITextField {
+    /// 텍스트필드의 플레이스홀더를 세팅하는 메소드
+    /// - Parameters:
+    ///   - title: 플레이스홀더의 텍스트
+    ///   - color: 플레이스홀더의 컬러
+    func setPlaceholder(title: String, color: UIColor) {
+        let title = title
+        self.attributedPlaceholder = NSAttributedString(
+            string: title,
+            attributes: [NSAttributedString.Key.foregroundColor: color,
+                         NSAttributedString.Key.font: UIFont.systemFont(ofSize: 14, weight: .regular)
+                        ]
+        )
+    }
+}

--- a/Lovechive/Lovechive/Source/AppHelpers/Extension/UITextField+Extension.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/Extension/UITextField+Extension.swift
@@ -8,6 +8,7 @@
 import UIKit
 
 extension UITextField {
+    
     /// 텍스트필드의 플레이스홀더를 세팅하는 메소드
     /// - Parameters:
     ///   - title: 플레이스홀더의 텍스트

--- a/Lovechive/Lovechive/Source/AppHelpers/FirestoreManager/DataModels/DiaryDataModel.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/FirestoreManager/DataModels/DiaryDataModel.swift
@@ -19,6 +19,7 @@ struct DiaryDataModel: FirestoreModelProtocol {
     
     func transform() -> [String : Any] {
         return [
+            AppConfig.DiariesModel.id: self.id,
             AppConfig.DiariesModel.author: self.author,
             AppConfig.DiariesModel.coupleId: self.coupleId,
             AppConfig.DiariesModel.content: self.content,

--- a/Lovechive/Lovechive/Source/AppHelpers/FirestoreManager/DataModels/ScheduleDataModel.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/FirestoreManager/DataModels/ScheduleDataModel.swift
@@ -11,10 +11,10 @@ import FirebaseFirestore
 
 /// Firestore의 schedules 컬렉션 데이터 모델
 struct ScheduleDataModel: FirestoreModelProtocol, IdentifiableType, Equatable {
-    typealias Identity = Int
+    typealias Identity = String
     
     var identity: Identity {
-        return self.date.hashValue
+        return self.id
     }
     
     let id: String
@@ -29,6 +29,7 @@ struct ScheduleDataModel: FirestoreModelProtocol, IdentifiableType, Equatable {
     
     func transform() -> [String : Any] {
         return [
+            AppConfig.SchedulesModel.id: self.id,
             AppConfig.SchedulesModel.title: self.title,
             AppConfig.SchedulesModel.coupleId: self.coupleId,
             AppConfig.SchedulesModel.date: Timestamp(date: self.date),

--- a/Lovechive/Lovechive/Source/AppHelpers/UIComponents/LogoView.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/UIComponents/LogoView.swift
@@ -14,6 +14,7 @@ final class LogoView: UIImageView {
         
         image = .logo
         contentMode = .scaleAspectFit
+        backgroundColor = .clear
     }
     
     required init?(coder: NSCoder) {

--- a/Lovechive/Lovechive/Source/AppHelpers/UserDefaultsManager/UserDefaultsManager.swift
+++ b/Lovechive/Lovechive/Source/AppHelpers/UserDefaultsManager/UserDefaultsManager.swift
@@ -12,7 +12,7 @@ struct UserDefaultsManager {
     
     var userId: String {
         guard let id = UserDefaults.standard.string(forKey: AppConfig.UserDefaultsConfig.userId) else {
-            return ""
+            return "0"
         }
         
         return id
@@ -20,7 +20,7 @@ struct UserDefaultsManager {
     
     var coupleId: String {
         guard let id = UserDefaults.standard.string(forKey: AppConfig.UserDefaultsConfig.coupleId) else {
-            return ""
+            return "0"
         }
         
         return id

--- a/Lovechive/Lovechive/Source/Model/AlertModel/AlertTextFieldModel.swift
+++ b/Lovechive/Lovechive/Source/Model/AlertModel/AlertTextFieldModel.swift
@@ -1,0 +1,25 @@
+//
+//  AlertTextFieldModel.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import UIKit
+
+enum AlertTextFieldModel {
+    case limit(value: Int)
+    case time
+    case calendar
+    
+    var buttonImage: UIImage? {
+        switch self {
+        case .limit:
+            return nil
+        case .time:
+            return UIImage.Icon.selectTimeIcon
+        case .calendar:
+            return UIImage.Icon.selectDateIcon
+        }
+    }
+}

--- a/Lovechive/Lovechive/Source/Model/AlertModel/AlertTextFieldModel.swift
+++ b/Lovechive/Lovechive/Source/Model/AlertModel/AlertTextFieldModel.swift
@@ -7,6 +7,7 @@
 
 import UIKit
 
+/// 커스텀 Alert 뷰의 텍스트필드 상태를 정의하는 모델
 enum AlertTextFieldModel {
     case limit(value: Int)
     case time

--- a/Lovechive/Lovechive/Source/Model/AlertModel/LovechiveAlertModel.swift
+++ b/Lovechive/Lovechive/Source/Model/AlertModel/LovechiveAlertModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 
+/// 커스텀 Alert뷰의 상태를 정의하는 모델
 enum AlertTypes {
     case newSchedule(date: Date)
     case editSchedule(data: ScheduleDataModel)
@@ -14,6 +15,7 @@ enum AlertTypes {
     case editDiary
     case editMyPage
     
+    /// Alert의 타이틀 뷰 텍스트
     var alertTitle: String {
         switch self {
         case .newSchedule:
@@ -29,6 +31,7 @@ enum AlertTypes {
         }
     }
     
+    /// Alert의 active 버튼 타이틀
     var alertActiveButtonTitle: String {
         switch self {
         case .newDiary, .newSchedule:
@@ -40,6 +43,7 @@ enum AlertTypes {
         }
     }
     
+    /// Alert의 타입에 따른 인덱스
     var typeIndex: Int {
         switch self {
         case .newSchedule, .editSchedule:

--- a/Lovechive/Lovechive/Source/Model/AlertModel/LovechiveAlertModel.swift
+++ b/Lovechive/Lovechive/Source/Model/AlertModel/LovechiveAlertModel.swift
@@ -1,0 +1,53 @@
+//
+//  LovechiveAlertModel.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import Foundation
+
+enum AlertTypes {
+    case newSchedule
+    case editSchedule
+    case newDiary
+    case editDiary
+    case editMyPage
+    
+    var alertTitle: String {
+        switch self {
+        case .newSchedule:
+            return "새 일정 추가하기"
+        case .editSchedule:
+            return "일정 수정하기"
+        case .newDiary:
+            return "새 다이어리 만들기"
+        case .editDiary:
+            return "다이어리 수정하기"
+        case .editMyPage:
+            return "내 정보 편집하기"
+        }
+    }
+    
+    var alertActiveButtonTitle: String {
+        switch self {
+        case .newDiary, .newSchedule:
+            return "만들기"
+        case .editDiary, .editSchedule:
+            return "수정하기"
+        case .editMyPage:
+            return "편집"
+        }
+    }
+    
+    var typeIndex: Int {
+        switch self {
+        case .newSchedule, .editSchedule:
+            return 0
+        case .newDiary, .editDiary:
+            return 1
+        case .editMyPage:
+            return 2
+        }
+    }
+}

--- a/Lovechive/Lovechive/Source/Model/AlertModel/LovechiveAlertModel.swift
+++ b/Lovechive/Lovechive/Source/Model/AlertModel/LovechiveAlertModel.swift
@@ -9,7 +9,7 @@ import Foundation
 
 enum AlertTypes {
     case newSchedule(date: Date)
-    case editSchedule(date: Date)
+    case editSchedule(data: ScheduleDataModel)
     case newDiary
     case editDiary
     case editMyPage

--- a/Lovechive/Lovechive/Source/Model/AlertModel/LovechiveAlertModel.swift
+++ b/Lovechive/Lovechive/Source/Model/AlertModel/LovechiveAlertModel.swift
@@ -8,8 +8,8 @@
 import Foundation
 
 enum AlertTypes {
-    case newSchedule
-    case editSchedule
+    case newSchedule(date: Date)
+    case editSchedule(date: Date)
     case newDiary
     case editDiary
     case editMyPage

--- a/Lovechive/Lovechive/Source/Model/MainPageModel/PlanTableViewDataSource.swift
+++ b/Lovechive/Lovechive/Source/Model/MainPageModel/PlanTableViewDataSource.swift
@@ -12,7 +12,7 @@ import RxDataSources
 import FirebaseFirestore
 
 /// 메인 페이지의 플래너 뷰 SectionModel
-struct PlanTableViewSection: AnimatableSectionModelType {
+struct ScheduleModelSection: AnimatableSectionModelType {
     typealias Identity = String
     typealias Item = ScheduleDataModel
     
@@ -25,7 +25,7 @@ struct PlanTableViewSection: AnimatableSectionModelType {
         self.items = items
     }
     
-    init(original: PlanTableViewSection, items: [Item]) {
+    init(original: ScheduleModelSection, items: [Item]) {
         self = original
         self.items = items
     }
@@ -33,15 +33,43 @@ struct PlanTableViewSection: AnimatableSectionModelType {
 
 // MARK: - MainPageViewController DataSource
 
-extension MainPageViewController {
-    typealias DataSource = RxTableViewSectionedAnimatedDataSource<PlanTableViewSection>
-    
+protocol ScheduleTableSectionConfigurable {
+    typealias DataSource = RxTableViewSectionedAnimatedDataSource<ScheduleModelSection>
+    var dataSource: DataSource { get }
+}
+
+extension MainPageViewController: ScheduleTableSectionConfigurable {
     var dataSource: DataSource {
-        let dataSource = DataSource(configureCell: { dataSource, tableView, indexPath, item in
+        let dataSource = DataSource(animationConfiguration:
+                                        AnimationConfiguration(insertAnimation: .fade,  // 삽입 시 애니메이션
+                                                               reloadAnimation: .fade,  // 변경 시 애니메이션 없음
+                                                               deleteAnimation: .left   // 삭제 시 왼쪽으로 사라짐
+            ), configureCell: { dataSource, tableView, indexPath, item in
             
             guard let cell = tableView.dequeueReusableCell(withIdentifier: AppConfig.PlanerView.cellId, for: indexPath) as? PlanViewCell else { return .init() }
             
             cell.configureCell(title: item.title, date: item.date)
+            cell.selectionStyle = .none
+            
+            return cell
+            
+        })
+        
+        return dataSource
+    }
+}
+
+extension CalendarViewController: ScheduleTableSectionConfigurable {
+    var dataSource: DataSource {
+        let dataSource = DataSource(animationConfiguration:
+                                        AnimationConfiguration(insertAnimation: .fade,  // 삽입 시 애니메이션
+                                                               reloadAnimation: .fade,  // 변경 시 애니메이션 없음
+                                                               deleteAnimation: .left   // 삭제 시 왼쪽으로 사라짐
+            ), configureCell: { dataSource, tableView, indexPath, item in
+            
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: AppConfig.CalendarViewConfig.cellId, for: indexPath) as? ScheduleViewCell else { return .init() }
+            
+            cell.configureCell(time: item.date, title: item.title)
             cell.selectionStyle = .none
             
             return cell

--- a/Lovechive/Lovechive/Source/Model/MainPageModel/PlanTableViewDataSource.swift
+++ b/Lovechive/Lovechive/Source/Model/MainPageModel/PlanTableViewDataSource.swift
@@ -43,7 +43,7 @@ extension MainPageViewController: ScheduleTableSectionConfigurable {
         let dataSource = DataSource(animationConfiguration:
                                         AnimationConfiguration(insertAnimation: .fade,  // 삽입 시 애니메이션
                                                                reloadAnimation: .fade,  // 변경 시 애니메이션 없음
-                                                               deleteAnimation: .left   // 삭제 시 왼쪽으로 사라짐
+                                                               deleteAnimation: .fade   // 삭제 시 왼쪽으로 사라짐
             ), configureCell: { dataSource, tableView, indexPath, item in
             
             guard let cell = tableView.dequeueReusableCell(withIdentifier: AppConfig.PlanerView.cellId, for: indexPath) as? PlanViewCell else { return .init() }
@@ -64,7 +64,7 @@ extension CalendarViewController: ScheduleTableSectionConfigurable {
         let dataSource = DataSource(animationConfiguration:
                                         AnimationConfiguration(insertAnimation: .fade,  // 삽입 시 애니메이션
                                                                reloadAnimation: .fade,  // 변경 시 애니메이션 없음
-                                                               deleteAnimation: .left   // 삭제 시 왼쪽으로 사라짐
+                                                               deleteAnimation: .fade   // 삭제 시 왼쪽으로 사라짐
             ), configureCell: { dataSource, tableView, indexPath, item in
             
             guard let cell = tableView.dequeueReusableCell(withIdentifier: AppConfig.CalendarViewConfig.cellId, for: indexPath) as? ScheduleViewCell else { return .init() }

--- a/Lovechive/Lovechive/Source/Model/MainPageModel/PlanTableViewDataSource.swift
+++ b/Lovechive/Lovechive/Source/Model/MainPageModel/PlanTableViewDataSource.swift
@@ -74,7 +74,7 @@ extension CalendarViewController: ScheduleTableSectionConfigurable {
             
             return cell
             
-        })
+        }, canEditRowAtIndexPath: { _, _ in true })
         
         return dataSource
     }

--- a/Lovechive/Lovechive/Source/Model/MainPageModel/PlanTableViewDataSource.swift
+++ b/Lovechive/Lovechive/Source/Model/MainPageModel/PlanTableViewDataSource.swift
@@ -31,12 +31,15 @@ struct ScheduleModelSection: AnimatableSectionModelType {
     }
 }
 
-// MARK: - MainPageViewController DataSource
+// MARK: - Schedule DataSource Protocol
 
+/// Schedule 타입의 데이터소스 공용 프로토콜
 protocol ScheduleTableSectionConfigurable {
     typealias DataSource = RxTableViewSectionedAnimatedDataSource<ScheduleModelSection>
     var dataSource: DataSource { get }
 }
+
+// MARK: - MainPageViewController DataSource
 
 extension MainPageViewController: ScheduleTableSectionConfigurable {
     var dataSource: DataSource {
@@ -58,6 +61,8 @@ extension MainPageViewController: ScheduleTableSectionConfigurable {
         return dataSource
     }
 }
+
+// MARK: - CalendarViewController DataSource
 
 extension CalendarViewController: ScheduleTableSectionConfigurable {
     var dataSource: DataSource {

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertButtonStackView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertButtonStackView.swift
@@ -1,0 +1,80 @@
+//
+//  AlertButtonStackView.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class AlertButtonStackView: UIView {
+    
+    fileprivate lazy var cancelButton = createdButton(title: "취소", color: .Gray.naturalBlack, backColor: .clear)
+    fileprivate lazy var activeButton = createdButton(title: "만들기", color: .white, backColor: .Personal.highlightPink)
+        
+    init(aletType: AlertTypes) {
+        super.init(frame: .zero)
+        
+        setupUI()
+        activeButton.setTitle(aletType.alertActiveButtonTitle, for: .normal)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension AlertButtonStackView {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        backgroundColor = .clear
+        [activeButton, cancelButton].forEach {
+            addSubview($0)
+        }
+    }
+    
+    func setupLayout() {
+        activeButton.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview()
+            $0.trailing.equalToSuperview()
+            $0.width.equalTo(72)
+        }
+        
+        cancelButton.snp.makeConstraints {
+            $0.verticalEdges.equalToSuperview()
+            $0.trailing.equalTo(activeButton.snp.leading).offset(-8)
+            $0.width.equalTo(72)
+        }
+    }
+    
+    func createdButton(title: String, color: UIColor, backColor: UIColor) -> UIButton {
+        let button = UIButton()
+        button.setTitle(title, for: .normal)
+        button.setTitleColor(color, for: .normal)
+        button.titleLabel?.font = .systemFont(ofSize: 14, weight: .regular)
+        button.backgroundColor = backColor
+        button.layer.cornerRadius = 8
+        
+        return button
+    }
+    
+}
+
+extension Reactive where Base: AlertButtonStackView {
+    var cancelButtonTapped: ControlEvent<Void> {
+        base.cancelButton.rx.tap
+    }
+    
+    var activeButtonTapped: ControlEvent<Void> {
+        base.activeButton.rx.tap
+    }
+}

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertButtonStackView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertButtonStackView.swift
@@ -10,11 +10,16 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+/// 커스텀 Alert의 취소, active 버튼을 표현하는 뷰
 final class AlertButtonStackView: UIView {
+    
+    // MARK: - UI Components
     
     fileprivate lazy var cancelButton = createdButton(title: "취소", color: .Gray.naturalBlack, backColor: .clear)
     fileprivate lazy var activeButton = createdButton(title: "만들기", color: .white, backColor: .Personal.highlightPink)
         
+    // MARK: - Initializer
+    
     init(aletType: AlertTypes) {
         super.init(frame: .zero)
         
@@ -27,6 +32,8 @@ final class AlertButtonStackView: UIView {
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension AlertButtonStackView {
     
@@ -69,11 +76,15 @@ private extension AlertButtonStackView {
     
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: AlertButtonStackView {
+    /// 취소 버튼을 눌렀을 때 이벤트를 방출하는 옵저버블
     var cancelButtonTapped: ControlEvent<Void> {
         base.cancelButton.rx.tap
     }
     
+    /// active 버튼을 눌렀을 때 이벤트를 방출하는 옵저버블
     var activeButtonTapped: ControlEvent<Void> {
         base.activeButton.rx.tap
     }

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertSectionCell.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertSectionCell.swift
@@ -1,0 +1,20 @@
+//
+//  AlertSectionCell.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import UIKit
+import SnapKit
+
+final class AlertSectionCell: UICollectionViewCell {
+    
+    func configureCell(_ view: UIView) {
+        addSubview(view)
+        view.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+}

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertSectionCell.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertSectionCell.swift
@@ -8,8 +8,11 @@
 import UIKit
 import SnapKit
 
+/// 커스텀 Alert뷰의 재활용 섹션의 셀 모델 정의
 final class AlertSectionCell: UICollectionViewCell {
     
+    /// 셀을 설정하는 메소드
+    /// - Parameter view: 셀에 넣을 뷰
     func configureCell(_ view: UIView) {
         addSubview(view)
         view.snp.makeConstraints {

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
@@ -1,0 +1,120 @@
+//
+//  AlerttextFieldView.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class AlertTextFieldView: UIView {
+    
+    fileprivate let textField = UITextField()
+    fileprivate let extraView: UIView
+    
+    init(type: AlertTextFieldModel, placeHolder: String) {
+        switch type {
+        case .limit:
+            extraView = UILabel()
+        case .time, .calendar:
+            extraView = UIButton()
+        }
+        
+        super.init(frame: .zero)
+        setupExtraView(type: type)
+        textField.setPlaceholder(title: placeHolder, color: .Gray.secondary)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension AlertTextFieldView {
+    
+    func setupUI() {
+        setuptextField()
+        configrueSelf()
+        setupLayout()
+    }
+    
+    func configrueSelf() {
+        backgroundColor = .clear
+        [textField, extraView].forEach {
+            addSubview($0)
+        }
+    }
+    
+    func setupLayout() {
+        textField.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        if extraView is UILabel {
+            extraView.snp.makeConstraints {
+                $0.centerY.equalToSuperview()
+                $0.trailing.equalTo(textField).inset(8)
+                $0.height.equalTo(20)
+            }
+        } else {
+            extraView.snp.makeConstraints {
+                $0.centerY.equalToSuperview()
+                $0.trailing.equalTo(textField).inset(8)
+                $0.width.height.equalTo(20)
+            }
+        }
+    }
+    
+    func setupExtraView(type: AlertTextFieldModel) {
+        switch type {
+        case .limit(value: let value):
+            guard let label = extraView as? UILabel else { return }
+            label.text = "0/\(value)" // 기본 값
+            label.font = .systemFont(ofSize: 14, weight: .regular)
+            label.textColor = .Gray.secondary
+            label.numberOfLines = 1
+            label.textAlignment = .right
+            label.backgroundColor = .clear
+            label.lineBreakMode = .byClipping
+            label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        case .time, .calendar:
+            guard let button = extraView as? UIButton else { return }
+            button.setImage(type.buttonImage, for: .normal)
+            button.backgroundColor = .clear
+            button.imageView?.contentMode = .scaleAspectFit
+            button.setContentHuggingPriority(.required, for: .horizontal)
+
+            textField.isUserInteractionEnabled = false
+        }
+    }
+    
+    func setuptextField() {
+        textField.font = .systemFont(ofSize: 14, weight: .regular)
+        textField.textColor = .Gray.naturalBlack
+        textField.borderStyle = .none
+        textField.clipsToBounds = true
+        textField.leftView = UIView(frame: .init(x: 0, y: 0, width: 8, height: 8))
+        textField.leftViewMode = .always
+        textField.rightView = UIView(frame: .init(x: 0, y: 0, width: 48, height: 8))
+        textField.rightViewMode = .always
+        textField.autocapitalizationType = .none
+        textField.backgroundColor = .white
+        
+        textField.layer.cornerRadius = 8
+        textField.layer.borderWidth = 1
+        textField.layer.borderColor = UIColor.Gray.secondary.cgColor
+    }
+    
+}
+
+extension Reactive where Base: AlertTextFieldView {
+    var editingTextField: ControlProperty<String?> {
+        base.textField.rx.text
+    }
+}

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
@@ -38,6 +38,11 @@ final class AlertTextFieldView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    func configureTextField(_ text: String) {
+        textField.text = text
+        textField.sendActions(for: .valueChanged)
+    }
+    
 }
 
 private extension AlertTextFieldView {

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
@@ -12,8 +12,13 @@ import RxCocoa
 
 final class AlertTextFieldView: UIView {
     
+    private var disposeBag = DisposeBag()
+    
+    private var currentType: AlertTextFieldModel
+    
     fileprivate let textField = UITextField()
-    fileprivate let extraView: UIView
+    private let datePicker = UIDatePicker()
+    private let extraView: UIView
     
     init(type: AlertTextFieldModel, placeHolder: String) {
         switch type {
@@ -22,9 +27,9 @@ final class AlertTextFieldView: UIView {
         case .time, .calendar:
             extraView = UIButton()
         }
+        currentType = type
         
         super.init(frame: .zero)
-        setupExtraView(type: type)
         textField.setPlaceholder(title: placeHolder, color: .Gray.secondary)
         setupUI()
     }
@@ -38,9 +43,11 @@ final class AlertTextFieldView: UIView {
 private extension AlertTextFieldView {
     
     func setupUI() {
+        setupExtraView()
         setuptextField()
         configrueSelf()
         setupLayout()
+        bind()
     }
     
     func configrueSelf() {
@@ -70,8 +77,8 @@ private extension AlertTextFieldView {
         }
     }
     
-    func setupExtraView(type: AlertTextFieldModel) {
-        switch type {
+    func setupExtraView() {
+        switch currentType {
         case .limit(value: let value):
             guard let label = extraView as? UILabel else { return }
             label.text = "0/\(value)" // 기본 값
@@ -85,12 +92,14 @@ private extension AlertTextFieldView {
 
         case .time, .calendar:
             guard let button = extraView as? UIButton else { return }
-            button.setImage(type.buttonImage, for: .normal)
+            button.setImage(currentType.buttonImage, for: .normal)
             button.backgroundColor = .clear
             button.imageView?.contentMode = .scaleAspectFit
             button.setContentHuggingPriority(.required, for: .horizontal)
 
-            textField.isUserInteractionEnabled = false
+//            textField.isUserInteractionEnabled = false
+//            textField.isEnabled = false
+            setupDatePicker()
         }
     }
     
@@ -111,10 +120,92 @@ private extension AlertTextFieldView {
         textField.layer.borderColor = UIColor.Gray.secondary.cgColor
     }
     
+    func mappingLimitText(_ view: UILabel, _ text: String) -> String {
+        let slice = view.text?.split(separator: "/")
+        let currentText = text.count
+        let limit = "\(currentText)/\(slice?.last ?? "")"
+        
+        return limit
+    }
+    
+    func checkInputLimit(_ input: String, _ view: UILabel) -> String {
+        guard let limit = Int(view.text?.split(separator: "/").last ?? ""),
+              input.count > limit
+        else { return input }
+        
+        let text = String(input.prefix(limit))
+        
+        HapticManager.notification(type: .warning)
+        
+        return text
+    }
+    
+    func setupDatePicker() {
+        switch currentType {
+        case .limit: break
+        case .time:
+            datePicker.datePickerMode = .time
+            datePicker.preferredDatePickerStyle = .wheels
+        case .calendar:
+            datePicker.datePickerMode = .date
+            datePicker.preferredDatePickerStyle = .wheels
+        }
+        
+        let toolbar = UIToolbar()
+        let doneButton = UIBarButtonItem(title: "완료", style: .done, target: self, action: #selector(dismissDatePicker))
+        let flexibleSpace = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
+        toolbar.setItems([flexibleSpace, doneButton], animated: false)
+        toolbar.sizeToFit()
+        
+        textField.inputView = datePicker
+        textField.inputAccessoryView = toolbar
+        textField.inputAssistantItem.leadingBarButtonGroups = []
+        textField.inputAssistantItem.trailingBarButtonGroups = []
+    }
+    
+    @objc func dismissDatePicker() {
+        var date: String = ""
+        
+        switch currentType {
+        case .limit: break
+        case .time:
+            date = datePicker.date.formattedDateToScheduleTime()
+        case .calendar:
+            date = datePicker.date.formattedDate()
+        }
+        
+        textField.text = date
+        textField.resignFirstResponder()
+    }
+    
+    func bind() {
+        if let button = extraView as? UIButton {
+            button.rx.tap
+                .withUnretained(self)
+                .asSignal(onErrorSignalWith: .empty())
+                .emit { owner, _ in
+                    owner.textField.becomeFirstResponder()
+                }
+                .disposed(by: disposeBag)
+            
+        } else if let label = extraView as? UILabel {
+            textField.rx.text.orEmpty
+                .distinctUntilChanged()
+                .withUnretained(self)
+                .map { owner, text in owner.checkInputLimit(text, label) }
+                .asDriver(onErrorDriveWith: .empty())
+                .drive { [weak self] text in
+                    self?.textField.text = text
+                    label.text = self?.mappingLimitText(label, text)
+                }
+                .disposed(by: disposeBag)
+        }
+    }
+    
 }
 
 extension Reactive where Base: AlertTextFieldView {
-    var editingTextField: ControlProperty<String?> {
-        base.textField.rx.text
+    var editingTextField: ControlProperty<String> {
+        base.textField.rx.text.orEmpty
     }
 }

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
@@ -10,15 +10,24 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+/// 커스텀 Alert뷰의 공용 텍스트필드 정의
 final class AlertTextFieldView: UIView {
+    
+    // MARK: - Rx Properties
     
     private var disposeBag = DisposeBag()
     
+    // MARK: - Properties
+    
     private var currentType: AlertTextFieldModel
+    
+    // MARK: - UI Components
     
     fileprivate let textField = UITextField()
     private let datePicker = UIDatePicker()
     private let extraView: UIView
+    
+    // MARK: - Initializer
     
     init(type: AlertTextFieldModel, placeHolder: String) {
         switch type {
@@ -38,12 +47,21 @@ final class AlertTextFieldView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// TextField를 텍스트를 설정하는 메소드
+    /// - Parameter text: TextField에 넣을 텍스트
     func configureTextField(_ text: String) {
         textField.text = text
         textField.sendActions(for: .valueChanged)
     }
     
+    /// 키보드를 등장 시키는 메소드
+    func showKeyboard() {
+        textField.becomeFirstResponder()
+    }
+    
 }
+
+// MARK: - UI Setting Method
 
 private extension AlertTextFieldView {
     
@@ -102,8 +120,6 @@ private extension AlertTextFieldView {
             button.imageView?.contentMode = .scaleAspectFit
             button.setContentHuggingPriority(.required, for: .horizontal)
 
-//            textField.isUserInteractionEnabled = false
-//            textField.isEnabled = false
             setupDatePicker()
         }
     }
@@ -123,26 +139,6 @@ private extension AlertTextFieldView {
         textField.layer.cornerRadius = 8
         textField.layer.borderWidth = 1
         textField.layer.borderColor = UIColor.Gray.secondary.cgColor
-    }
-    
-    func mappingLimitText(_ view: UILabel, _ text: String) -> String {
-        let slice = view.text?.split(separator: "/")
-        let currentText = text.count
-        let limit = "\(currentText)/\(slice?.last ?? "")"
-        
-        return limit
-    }
-    
-    func checkInputLimit(_ input: String, _ view: UILabel) -> String {
-        guard let limit = Int(view.text?.split(separator: "/").last ?? ""),
-              input.count > limit
-        else { return input }
-        
-        let text = String(input.prefix(limit))
-        
-        HapticManager.notification(type: .warning)
-        
-        return text
     }
     
     func setupDatePicker() {
@@ -168,6 +164,7 @@ private extension AlertTextFieldView {
         textField.inputAssistantItem.trailingBarButtonGroups = []
     }
     
+    /// DatePicker 뷰를 닫는 메소드
     @objc func dismissDatePicker() {
         var date: String = ""
         
@@ -183,6 +180,41 @@ private extension AlertTextFieldView {
         textField.resignFirstResponder()
     }
     
+    /// TextField의 글자 수를 표현하는 메소드
+    /// - Parameters:
+    ///   - view: 글자수를 표현할 뷰
+    ///   - text: TextField의 텍스트
+    /// - Returns: 현재 글자 수/최대 글자 수
+    func mappingLimitText(_ view: UILabel, _ text: String) -> String {
+        let slice = view.text?.split(separator: "/")
+        let currentText = text.count
+        let limit = "\(currentText)/\(slice?.last ?? "")"
+        
+        return limit
+    }
+    
+    /// TextField의 글자 수가 제한 숫자보다 큰지 확인하는 메소드
+    /// - Parameters:
+    ///   - input: TextField의 텍스트
+    ///   - view: 최대 글자 수를 가진 뷰
+    /// - Returns: 최대 글자 수보다 작은 수의 텍스트
+    func checkInputLimit(_ input: String, _ view: UILabel) -> String {
+        guard let limit = Int(view.text?.split(separator: "/").last ?? ""),
+              input.count > limit
+        else {
+            view.textColor = .Gray.secondary
+            return input
+        }
+        
+        let text = String(input.prefix(limit))
+        view.textColor = .systemRed
+        
+        HapticDrawer.notification(type: .warning)
+        
+        return text
+    }
+    
+    /// 데이터 바인딩 메소드
     func bind() {
         if let button = extraView as? UIButton {
             button.rx.tap
@@ -209,7 +241,10 @@ private extension AlertTextFieldView {
     
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: AlertTextFieldView {
+    /// TextField의 값이 변경되었을 때 이벤트를 방출하는 메소드
     var editingTextField: ControlProperty<String> {
         base.textField.rx.text.orEmpty
     }

--- a/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/AlertTextFieldView.swift
@@ -174,9 +174,9 @@ private extension AlertTextFieldView {
         switch currentType {
         case .limit: break
         case .time:
-            date = datePicker.date.formattedDateToScheduleTime()
+            date = datePicker.date.formattedDateToString(.hourMinute)
         case .calendar:
-            date = datePicker.date.formattedDate()
+            date = datePicker.date.formattedDateToString(.yearMonthDay)
         }
         
         textField.text = date

--- a/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
@@ -30,6 +30,7 @@ final class LovechiveAlertView: UIView {
     ]
     
     private var currentSectionIndex: Int
+    private var currentType: FirestoreModelProtocol?
     
     init(type: AlertTypes) {
         buttonView = .init(aletType: type)
@@ -38,6 +39,7 @@ final class LovechiveAlertView: UIView {
         
         titleView.text = type.alertTitle
         sectionView.setCollectionViewLayout(createdCollectionViewLayout(items: sections[currentSectionIndex].count), animated: false)
+        editData(type: type)
         setupUI()
     }
     
@@ -123,6 +125,23 @@ private extension LovechiveAlertView {
         return layout
     }
     
+    func editData(type: AlertTypes) {
+        switch type {
+        case .newSchedule, .newDiary: break
+        case .editSchedule(data: let data):
+            let section = sections[0]
+            guard let firstView = section[0] as? AlertTextFieldView,
+                  let secondView = section[1] as? AlertTextFieldView
+            else { return }
+            
+            firstView.configureTextField(data.date.formattedDateToScheduleTime())
+            secondView.configureTextField(data.title)
+            
+        case .editDiary: break
+        case .editMyPage: break
+        }
+    }
+        
     func bind() {
         sections[currentSectionIndex].enumerated().forEach { [weak self] (index, section) in
             guard let self else { return }

--- a/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
@@ -16,6 +16,13 @@ final class LovechiveAlertView: UIView {
     fileprivate let buttonView: AlertButtonStackView
     private lazy var sectionView = UICollectionView(frame: .zero, collectionViewLayout: createdCollectionViewLayout(items: 1))
     
+    private var disposeBag = DisposeBag()
+    
+    fileprivate let firstSectionTextFieldRelay = BehaviorRelay<String>(value: "")
+    fileprivate let secondSectionTextFieldRelay = BehaviorRelay<String>(value: "")
+    fileprivate let thirdSectionTextFieldRelay = BehaviorRelay<String>(value: "")
+    fileprivate let thirdSectionColorRelay = BehaviorRelay<String>(value: "")
+    
     private lazy var sections: [[UIView]] = [
         [AlertTextFieldView(type: .time, placeHolder: "시간 선택"), AlertTextFieldView(type: .limit(value: 20), placeHolder: "일정 설명")],
         [AlertTextFieldView(type: .limit(value: 10), placeHolder: "다이어리 제목"), AlertTextFieldView(type: .limit(value: 20), placeHolder: "다이어리 설명")],
@@ -54,6 +61,7 @@ private extension LovechiveAlertView {
         setupTitle()
         configureSelf()
         setupLayout()
+        bind()
     }
     
     func configureSelf() {
@@ -115,6 +123,19 @@ private extension LovechiveAlertView {
         return layout
     }
     
+    func bind() {
+        sections[currentSectionIndex].enumerated().forEach { [weak self] (index, section) in
+            guard let self else { return }
+            if let view = section as? AlertTextFieldView, index == 0 {
+                view.rx.editingTextField.bind(to: self.firstSectionTextFieldRelay).disposed(by: disposeBag)
+            } else if let view = section as? AlertTextFieldView, index == 1 {
+                view.rx.editingTextField.bind(to: self.secondSectionTextFieldRelay).disposed(by: disposeBag)
+            } else if let view = section as? AlertTextFieldView, index == 1 {
+                // 추후 구현
+            }
+        }
+    }
+    
 }
 
 extension LovechiveAlertView: UICollectionViewDataSource {
@@ -146,5 +167,21 @@ extension Reactive where Base: LovechiveAlertView {
     
     var activeButtonTapped: ControlEvent<Void> {
         return base.buttonView.rx.activeButtonTapped
+    }
+    
+    var firstSectionTextFieldRelay: BehaviorRelay<String> {
+        return base.firstSectionTextFieldRelay
+    }
+    
+    var secondSectionTextFieldRelay: BehaviorRelay<String> {
+        return base.secondSectionTextFieldRelay
+    }
+    
+    var thirdSectionTextFieldRelay: BehaviorRelay<String> {
+        return base.thirdSectionTextFieldRelay
+    }
+    
+    var thirdSectionColorRelay: BehaviorRelay<String> {
+        return base.thirdSectionColorRelay
     }
 }

--- a/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
@@ -10,11 +10,16 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+/// 커스텀 Alert 뷰
 final class LovechiveAlertView: UIView {
         
+    // MARK: - UI Components
+    
     private let titleView = UILabel()
     fileprivate let buttonView: AlertButtonStackView
     private lazy var sectionView = UICollectionView(frame: .zero, collectionViewLayout: createdCollectionViewLayout(items: 1))
+    
+    // MARK: - Rx Properties
     
     private var disposeBag = DisposeBag()
     
@@ -23,6 +28,8 @@ final class LovechiveAlertView: UIView {
     fileprivate let thirdSectionTextFieldRelay = BehaviorRelay<String>(value: "")
     fileprivate let thirdSectionColorRelay = BehaviorRelay<String>(value: "")
     
+    // MARK: - Properties
+    
     private lazy var sections: [[UIView]] = [
         [AlertTextFieldView(type: .time, placeHolder: "시간 선택"), AlertTextFieldView(type: .limit(value: 20), placeHolder: "일정 설명")],
         [AlertTextFieldView(type: .limit(value: 10), placeHolder: "다이어리 제목"), AlertTextFieldView(type: .limit(value: 20), placeHolder: "다이어리 설명")],
@@ -30,7 +37,8 @@ final class LovechiveAlertView: UIView {
     ]
     
     private var currentSectionIndex: Int
-    private var currentType: FirestoreModelProtocol?
+    
+    // MARK: - Initializer
     
     init(type: AlertTypes) {
         buttonView = .init(aletType: type)
@@ -47,6 +55,7 @@ final class LovechiveAlertView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 커스텀 Alert 뷰의 섹션 사이즈를 업데이트 하는 메소드
     func updateSectionViewSize() {
         let constraint: Int = currentSectionIndex == 2 ? 64 : 48
         sectionView.layoutIfNeeded()
@@ -54,7 +63,19 @@ final class LovechiveAlertView: UIView {
             $0.height.equalTo(constraint * self.sections[self.currentSectionIndex].count)
         }
     }
+    
+    /// 키보드를 등장 시키는 메소드
+    func showKeyboard() {
+        let indexPath = IndexPath(item: 0, section: 0)
+        guard let cell = sectionView.cellForItem(at: indexPath) as? AlertSectionCell,
+              let view = cell.subviews.last as? AlertTextFieldView
+        else { return }
+        
+        view.showKeyboard()
+    }
 }
+
+// MARK: - UI Setting Method
 
 private extension LovechiveAlertView {
     
@@ -149,13 +170,15 @@ private extension LovechiveAlertView {
                 view.rx.editingTextField.bind(to: self.firstSectionTextFieldRelay).disposed(by: disposeBag)
             } else if let view = section as? AlertTextFieldView, index == 1 {
                 view.rx.editingTextField.bind(to: self.secondSectionTextFieldRelay).disposed(by: disposeBag)
-            } else if let view = section as? AlertTextFieldView, index == 1 {
+            } else if let view = section as? AlertTextFieldView, index == 2 {
                 // 추후 구현
             }
         }
     }
     
 }
+
+// MARK: - UICollectionViewDataSource Method
 
 extension LovechiveAlertView: UICollectionViewDataSource {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
@@ -174,32 +197,42 @@ extension LovechiveAlertView: UICollectionViewDataSource {
     }
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: LovechiveAlertView {
+    
+    /// 커스텀 Alert뷰의 서브뷰들이 모두 설정되었을 때 이벤트를 방출하는 옵저버블
     var layoutSubviewsEvent: Observable<Void> {
         return base.rx.methodInvoked(#selector(base.layoutSubviews))
             .map { _ in } // 반환값을 Void로 변환
     }
     
+    /// 취소 버튼의 탭 이벤트를 방출하는 옵저버블
     var cancelButtonTapped: ControlEvent<Void> {
         return base.buttonView.rx.cancelButtonTapped
     }
     
+    /// active 버튼의 탭 이벤트를 방출하는 옵저버블
     var activeButtonTapped: ControlEvent<Void> {
         return base.buttonView.rx.activeButtonTapped
     }
     
+    /// 첫 번째 섹션의 TextField 변경 이벤트를 방출하는 옵저버블
     var firstSectionTextFieldRelay: BehaviorRelay<String> {
         return base.firstSectionTextFieldRelay
     }
     
+    /// 두 번째 섹션의 TextField 변경 이벤트를 방출하는 옵저버블
     var secondSectionTextFieldRelay: BehaviorRelay<String> {
         return base.secondSectionTextFieldRelay
     }
     
+    /// 세 번째 섹션의 TextField 변경 이벤트를 방출하는 옵저버블
     var thirdSectionTextFieldRelay: BehaviorRelay<String> {
         return base.thirdSectionTextFieldRelay
     }
     
+    /// 세 번째 섹션의 색상 변경 이벤트를 방출하는 옵저버블
     var thirdSectionColorRelay: BehaviorRelay<String> {
         return base.thirdSectionColorRelay
     }

--- a/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
@@ -1,0 +1,150 @@
+//
+//  LovechiveAlertView.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class LovechiveAlertView: UIView {
+        
+    private let titleView = UILabel()
+    fileprivate let buttonView: AlertButtonStackView
+    private lazy var sectionView = UICollectionView(frame: .zero, collectionViewLayout: createdCollectionViewLayout(items: 1))
+    
+    private lazy var sections: [[UIView]] = [
+        [AlertTextFieldView(type: .time, placeHolder: "시간 선택"), AlertTextFieldView(type: .limit(value: 20), placeHolder: "일정 설명")],
+        [AlertTextFieldView(type: .limit(value: 10), placeHolder: "다이어리 제목"), AlertTextFieldView(type: .limit(value: 20), placeHolder: "다이어리 설명")],
+        []
+    ]
+    
+    private var currentSectionIndex: Int
+    
+    init(type: AlertTypes) {
+        buttonView = .init(aletType: type)
+        currentSectionIndex = type.typeIndex
+        super.init(frame: .zero)
+        
+        titleView.text = type.alertTitle
+        sectionView.setCollectionViewLayout(createdCollectionViewLayout(items: sections[currentSectionIndex].count), animated: false)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func updateSectionViewSize() {
+        let constraint: Int = currentSectionIndex == 2 ? 64 : 48
+        sectionView.layoutIfNeeded()
+        sectionView.snp.updateConstraints {
+            $0.height.equalTo(constraint * self.sections[self.currentSectionIndex].count)
+        }
+    }
+}
+
+private extension LovechiveAlertView {
+    
+    func setupUI() {
+        setupSectinoView()
+        setupTitle()
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        backgroundColor = .white
+        layer.cornerRadius = 16
+        [titleView, sectionView, buttonView].forEach {
+            addSubview($0)
+        }
+    }
+    
+    func setupLayout() {
+        titleView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(30)
+        }
+        
+        sectionView.snp.makeConstraints {
+            $0.top.equalTo(titleView.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(96) // 기본 높이
+        }
+        
+        buttonView.snp.makeConstraints {
+            $0.top.equalTo(sectionView.snp.bottom).offset(16)
+            $0.bottom.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(40)
+        }
+    }
+    
+    func setupTitle() {
+        titleView.font = .systemFont(ofSize: 16, weight: .bold)
+        titleView.textColor = .Gray.naturalBlack
+        titleView.numberOfLines = 1
+        titleView.textAlignment = .left
+        titleView.backgroundColor = .clear
+    }
+    
+    func setupSectinoView() {
+        sectionView.backgroundColor = .clear
+        sectionView.isScrollEnabled = false
+        sectionView.showsHorizontalScrollIndicator = false
+        sectionView.showsVerticalScrollIndicator = false
+        sectionView.dataSource = self
+        sectionView.register(AlertSectionCell.self, forCellWithReuseIdentifier: "AlertSectionCell")
+    }
+    
+    func createdCollectionViewLayout(items: Int) -> UICollectionViewLayout {
+        let itemSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1 / CGFloat(items)))
+        let item = NSCollectionLayoutItem(layoutSize: itemSize)
+        
+        let groupSize = NSCollectionLayoutSize(widthDimension: .fractionalWidth(1), heightDimension: .fractionalHeight(1))
+        let group = NSCollectionLayoutGroup.vertical(layoutSize: groupSize, subitems: [item])
+        group.interItemSpacing = .fixed(16)
+        
+        let section = NSCollectionLayoutSection(group: group)
+        
+        let layout = UICollectionViewCompositionalLayout(section: section)
+        
+        return layout
+    }
+    
+}
+
+extension LovechiveAlertView: UICollectionViewDataSource {
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        sections[currentSectionIndex].count
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "AlertSectionCell", for: indexPath) as? AlertSectionCell else {
+            return UICollectionViewCell()
+        }
+        
+        cell.configureCell(sections[currentSectionIndex][indexPath.item])
+        cell.backgroundColor = .clear
+        
+        return cell
+    }
+}
+
+extension Reactive where Base: LovechiveAlertView {
+    var layoutSubviewsEvent: Observable<Void> {
+        return base.rx.methodInvoked(#selector(base.layoutSubviews))
+            .map { _ in } // 반환값을 Void로 변환
+    }
+    
+    var cancelButtonTapped: ControlEvent<Void> {
+        return base.buttonView.rx.cancelButtonTapped
+    }
+    
+    var activeButtonTapped: ControlEvent<Void> {
+        return base.buttonView.rx.activeButtonTapped
+    }
+}

--- a/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertView.swift
@@ -134,7 +134,7 @@ private extension LovechiveAlertView {
                   let secondView = section[1] as? AlertTextFieldView
             else { return }
             
-            firstView.configureTextField(data.date.formattedDateToScheduleTime())
+            firstView.configureTextField(data.date.formattedDateToString(.hourMinute))
             secondView.configureTextField(data.title)
             
         case .editDiary: break

--- a/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertViewController.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertViewController.swift
@@ -1,0 +1,118 @@
+//
+//  LovechiveAlertViewController.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class LovechiveAlertViewController: UIViewController {
+    
+    private var disposeBag = DisposeBag()
+    
+    private let viewModel = LovechiveAlertViewModel()
+    
+    private let alertView: LovechiveAlertView
+    private let dim = UIView()
+    
+    init(type: AlertTypes) {
+        alertView = .init(type: type)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupUI()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        showAlertView()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        super.touchesBegan(touches, with: event)
+        
+        self.view.endEditing(true)
+    }
+    
+    func dismissSelf(_ completion: @escaping () -> Void) {
+        UIView.animate(withDuration: 0.3) {
+            self.dim.alpha = 0
+            self.alertView.frame.origin.y = self.view.frame.maxY + 50
+        } completion: { _ in
+            completion()
+        }
+    }
+}
+
+private extension LovechiveAlertViewController {
+    
+    func setupUI() {
+        setupDim()
+        configureSelf()
+        setupLayout()
+        bind()
+    }
+    
+    func configureSelf() {
+        view.backgroundColor = .clear
+        [dim, alertView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    func setupLayout() {
+        dim.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        alertView.snp.makeConstraints {
+            $0.center.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        alertView.frame.origin.y = view.frame.maxY + 50
+    }
+    
+    func setupDim() {
+        dim.backgroundColor = .black
+        dim.alpha = 0
+    }
+    
+    func showAlertView() {
+        UIView.animate(withDuration: 0.3) {
+            self.dim.alpha = 0.25
+            self.alertView.frame.origin.y = self.view.frame.midY
+        } completion: { _ in
+            // 키보드 열기
+        }
+    }
+    
+    func bind() {
+        let input = LovechiveAlertViewModel.Input(cancelButtonTapped: alertView.rx.cancelButtonTapped,
+                                                  activeButtonTapped: alertView.rx.activeButtonTapped
+        )
+        
+        let output = viewModel.transform(input: input)
+        
+        alertView.rx.layoutSubviewsEvent
+            .withUnretained(self)
+            .asSignal(onErrorSignalWith: .empty())
+            .emit { owner, _ in
+                owner.alertView.updateSectionViewSize()
+            }
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertViewController.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertViewController.swift
@@ -10,15 +10,24 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+/// 커스텀 Alert 뷰 컨트롤러
 final class LovechiveAlertViewController: UIViewController {
+    
+    // MARK: - Rx Properties
     
     private var disposeBag = DisposeBag()
     fileprivate let dataSavedRelay = PublishRelay<Void>()
     
+    // MARK: - Properties
+    
     private let viewModel: LovechiveAlertViewModel
+    
+    // MARK: - UI Components
     
     private(set) var alertView: LovechiveAlertView
     private let dim = UIView()
+    
+    // MARK: - Initializer
     
     init(type: AlertTypes) {
         alertView = .init(type: type)
@@ -29,6 +38,8 @@ final class LovechiveAlertViewController: UIViewController {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+    
+    // MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -42,12 +53,15 @@ final class LovechiveAlertViewController: UIViewController {
         showAlertView()
     }
     
+    // 키보드 내리기 설정
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         super.touchesBegan(touches, with: event)
         
         self.view.endEditing(true)
     }
     
+    /// LovechiveAlertView를 화면에서 없애는 메소드
+    /// - Parameter completion: 뷰가 화면에서 없어진 뒤에 실행할 동작
     func dismissSelf(_ completion: @escaping () -> Void) {
         UIView.animate(withDuration: 0.3) {
             self.dim.alpha = 0
@@ -58,6 +72,8 @@ final class LovechiveAlertViewController: UIViewController {
         }
     }
 }
+
+// MARK: - UI Setting Method
 
 private extension LovechiveAlertViewController {
     
@@ -98,7 +114,7 @@ private extension LovechiveAlertViewController {
             self.dim.alpha = 0.25
             self.alertView.frame.origin.y = self.view.frame.midY
         } completion: { _ in
-            // 키보드 열기
+            self.alertView.showKeyboard()
         }
     }
     
@@ -126,7 +142,10 @@ private extension LovechiveAlertViewController {
     
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: LovechiveAlertViewController {
+    /// 데이터 저장이 완료되면 이벤트를 방출하는 옵저버블
     var dataSavedRelay: PublishRelay<Void> {
         base.dataSavedRelay
     }

--- a/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertViewController.swift
+++ b/Lovechive/Lovechive/Source/View/AlertView/LovechiveAlertViewController.swift
@@ -13,14 +13,16 @@ import RxCocoa
 final class LovechiveAlertViewController: UIViewController {
     
     private var disposeBag = DisposeBag()
+    fileprivate let dataSavedRelay = PublishRelay<Void>()
     
-    private let viewModel = LovechiveAlertViewModel()
+    private let viewModel: LovechiveAlertViewModel
     
-    private let alertView: LovechiveAlertView
+    private(set) var alertView: LovechiveAlertView
     private let dim = UIView()
     
     init(type: AlertTypes) {
         alertView = .init(type: type)
+        viewModel = .init(type: type)
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -50,6 +52,7 @@ final class LovechiveAlertViewController: UIViewController {
         UIView.animate(withDuration: 0.3) {
             self.dim.alpha = 0
             self.alertView.frame.origin.y = self.view.frame.maxY + 50
+            self.view.endEditing(true)
         } completion: { _ in
             completion()
         }
@@ -101,7 +104,9 @@ private extension LovechiveAlertViewController {
     
     func bind() {
         let input = LovechiveAlertViewModel.Input(cancelButtonTapped: alertView.rx.cancelButtonTapped,
-                                                  activeButtonTapped: alertView.rx.activeButtonTapped
+                                                  activeButtonTapped: alertView.rx.activeButtonTapped,
+                                                  scheduleTimeRelay: alertView.rx.firstSectionTextFieldRelay,
+                                                  scheduleTitleRelay: alertView.rx.secondSectionTextFieldRelay
         )
         
         let output = viewModel.transform(input: input)
@@ -113,6 +118,16 @@ private extension LovechiveAlertViewController {
                 owner.alertView.updateSectionViewSize()
             }
             .disposed(by: disposeBag)
+        
+        output.dataSaved
+            .bind(to: dataSavedRelay)
+            .disposed(by: disposeBag)
     }
     
+}
+
+extension Reactive where Base: LovechiveAlertViewController {
+    var dataSavedRelay: PublishRelay<Void> {
+        base.dataSavedRelay
+    }
 }

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarHeaderView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarHeaderView.swift
@@ -28,7 +28,7 @@ final class CalendarHeaderView: UIView {
     }
     
     func configureHeaderView(_ date: Date) {
-        dateTitle.text = date.formattedDateToYM()
+        dateTitle.text = date.formattedDateToString(.yearMonth)
     }
 }
 

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarHeaderView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarHeaderView.swift
@@ -10,12 +10,17 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+/// 캘린더 헤더 뷰
 final class CalendarHeaderView: UIView {
+    
+    // MARK: - UI Components
     
     fileprivate lazy var previousButton = createButton(title: "<")
     fileprivate lazy var nextButton = createButton(title: ">")
     private let dateTitle = UILabel()
     private let headerStackView = UIStackView()
+    
+    // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -27,10 +32,14 @@ final class CalendarHeaderView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 헤더뷰를 설정하는 메소드
+    /// - Parameter date: 헤더뷰 타이틀에 들어갈 Date
     func configureHeaderView(_ date: Date) {
         dateTitle.text = date.formattedDateToString(.yearMonth)
     }
 }
+
+// MARK: - UI Setting Method
 
 private extension CalendarHeaderView {
     
@@ -92,11 +101,15 @@ private extension CalendarHeaderView {
     
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: CalendarHeaderView {
+    /// 이전 버튼의 탭 이벤트를 방출하는 옵저버블
     var previousButtonTapped: ControlEvent<Void> {
         base.previousButton.rx.tap
     }
     
+    /// 다음 버튼의 탭 이벤트를 방출하는 옵저버블
     var nextButtonTapped: ControlEvent<Void> {
         base.nextButton.rx.tap
     }

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarHeaderView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarHeaderView.swift
@@ -1,0 +1,103 @@
+//
+//  CalendarHeaderView.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/11/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class CalendarHeaderView: UIView {
+    
+    fileprivate lazy var previousButton = createButton(title: "<")
+    fileprivate lazy var nextButton = createButton(title: ">")
+    private let dateTitle = UILabel()
+    private let headerStackView = UIStackView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureHeaderView(_ date: Date) {
+        dateTitle.text = date.formattedDateToYM()
+    }
+}
+
+private extension CalendarHeaderView {
+    
+    func setupUI() {
+        setupStackView()
+        setupDateTitle()
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        backgroundColor = .white
+        layer.cornerRadius = 16
+        addSubview(headerStackView)
+    }
+    
+    func setupLayout() {
+        headerStackView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        
+        previousButton.snp.makeConstraints {
+            $0.width.height.equalTo(60)
+        }
+        
+        nextButton.snp.makeConstraints {
+            $0.width.height.equalTo(60)
+        }
+    }
+    
+    func createButton(title: String) -> UIButton {
+        let button = UIButton()
+        button.backgroundColor = .clear
+        button.setTitle(title, for: .normal)
+        button.setTitleColor(.Personal.highlightPink, for: .normal)
+        button.titleLabel?.font = .myoyaFont(24)
+        
+        return button
+    }
+    
+    func setupDateTitle() {
+        dateTitle.text = AppConfig.CalendarViewConfig.headerDate
+        dateTitle.font = .myoyaFont(24)
+        dateTitle.textColor = .Personal.highlightPink
+        dateTitle.numberOfLines = 1
+        dateTitle.textAlignment = .center
+    }
+    
+    func setupStackView() {
+        headerStackView.spacing = 0
+        headerStackView.axis = .horizontal
+        headerStackView.alignment = .fill
+        headerStackView.distribution = .fill
+        headerStackView.backgroundColor = .clear
+        [previousButton, dateTitle, nextButton].forEach {
+            headerStackView.addArrangedSubview($0)
+        }
+    }
+    
+}
+
+extension Reactive where Base: CalendarHeaderView {
+    var previousButtonTapped: ControlEvent<Void> {
+        base.previousButton.rx.tap
+    }
+    
+    var nextButtonTapped: ControlEvent<Void> {
+        base.nextButton.rx.tap
+    }
+}

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarView.swift
@@ -36,6 +36,8 @@ final class CalendarView: UIView {
     func changeCurrentPage(_ date: Date) {
         calendar.scrollEnabled = true
         calendar.setCurrentPage(date, animated: true)
+        calendar.select(date)
+        selectedDate.accept(date)
         calendar.scrollEnabled = false
     }
 }

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarView.swift
@@ -1,0 +1,118 @@
+//
+//  CalendarView.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/11/25.
+//
+
+import UIKit
+import FSCalendar
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class CalendarView: UIView {
+    
+    private var eventDates: [Date] = []
+    
+    fileprivate let selectedDate = BehaviorRelay<Date>(value: Date())
+    
+    private let calendar = FSCalendar()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func setupEvents(_ events: [Date]) {
+        eventDates = events
+        calendar.reloadData()
+    }
+    
+    func changeCurrentPage(_ date: Date) {
+        calendar.scrollEnabled = true
+        calendar.setCurrentPage(date, animated: true)
+        calendar.scrollEnabled = false
+    }
+}
+
+private extension CalendarView {
+    
+    func setupUI() {
+        setupCalendar()
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        backgroundColor = .white
+        clipsToBounds = true
+        layer.cornerRadius = 16
+        addSubview(calendar)
+    }
+    
+    func setupLayout() {
+        calendar.snp.makeConstraints {
+            $0.edges.equalToSuperview().inset(16)
+        }
+    }
+    
+    func setupCalendar() {
+        calendar.backgroundColor = .clear
+        calendar.setCurrentPage(Date(), animated: false)
+        calendar.firstWeekday = 1
+        calendar.select(Date())
+        calendar.allowsMultipleSelection = false
+        calendar.locale = Locale(identifier: "ko_KR")
+        calendar.formatter.timeZone = TimeZone(identifier: "Asiz/Seoul")
+        calendar.placeholderType = .fillHeadTail
+        calendar.scrollEnabled = false
+        calendar.headerHeight = 0
+        calendar.appearance.headerMinimumDissolvedAlpha = 0
+        calendar.rowHeight = 48
+        calendar.weekdayHeight = 48
+        calendar.delegate = self
+        calendar.dataSource = self
+        
+        calendar.appearance.weekdayFont = .myoyaFont(20)
+        calendar.appearance.weekdayTextColor = .Personal.deepPink
+        
+        calendar.appearance.titleFont = .myoyaFont(16)
+        calendar.appearance.titleDefaultColor = .Personal.highlightPink
+        calendar.appearance.titleTodayColor = .Personal.lightPink
+        
+        calendar.appearance.selectionColor = .Personal.highlightPink
+        calendar.appearance.borderRadius = 0.5
+        
+        calendar.appearance.todayColor = .clear
+        calendar.appearance.todaySelectionColor = .Personal.highlightPink
+        
+        calendar.appearance.eventDefaultColor = .Personal.pointPink
+        calendar.appearance.eventSelectionColor = .Personal.pointPink
+    }
+    
+}
+
+extension CalendarView: FSCalendarDelegate {
+    func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
+        selectedDate.accept(date)
+    }
+}
+
+extension CalendarView: FSCalendarDataSource {
+    func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
+        let events = eventDates.filter { Calendar.current.isDate($0, equalTo: date, toGranularity: .day) }
+        
+        return events.isEmpty ? 0 : min(3, events.count)
+    }
+}
+
+extension Reactive where Base: CalendarView {
+    var selectedDate: BehaviorRelay<Date> {
+        base.selectedDate
+    }
+}

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarView.swift
@@ -11,13 +11,22 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+/// 캘린더 뷰
 final class CalendarView: UIView {
+    
+    // MARK: - Properties
     
     private var eventDates: [Date] = []
     
+    // MARK: - Rx Properties
+    
     fileprivate let selectedDate = BehaviorRelay<Date>(value: Date())
     
+    // MARK: - UI Components
+    
     private let calendar = FSCalendar()
+    
+    // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -28,11 +37,15 @@ final class CalendarView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 이벤트를 설정하는 메소드
+    /// - Parameter events: 이벤트가 담긴 Date 배열
     func setupEvents(_ events: [Date]) {
         eventDates = events
         calendar.reloadData()
     }
     
+    /// 현재 캘린더의 페이지를 변경하는 메소드
+    /// - Parameter date: 변경할 날짜
     func changeCurrentPage(_ date: Date) {
         calendar.scrollEnabled = true
         calendar.setCurrentPage(date, animated: true)
@@ -41,6 +54,8 @@ final class CalendarView: UIView {
         calendar.scrollEnabled = false
     }
 }
+
+// MARK: - UI Setting Method
 
 private extension CalendarView {
     
@@ -99,13 +114,19 @@ private extension CalendarView {
     
 }
 
+// MARK: - FSCalendarDelegate Method
+
 extension CalendarView: FSCalendarDelegate {
+    // 특정 날짜를 선택했을 때 발생하는 메소드
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         selectedDate.accept(date)
     }
 }
 
+// MARK: - FSCalendarDataSource Method
+
 extension CalendarView: FSCalendarDataSource {
+    // 이벤트 UI를 설정하는 메소드
     func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {
         let events = eventDates.filter { Calendar.current.isDate($0, equalTo: date, toGranularity: .day) }
         
@@ -113,7 +134,10 @@ extension CalendarView: FSCalendarDataSource {
     }
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: CalendarView {
+    /// 특정 날짜를 선택했을 때 날짜에 대한 이벤트를 방출하는 옵저버블
     var selectedDate: BehaviorRelay<Date> {
         base.selectedDate
     }

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
@@ -70,7 +70,8 @@ private extension CalendarViewController {
                                             previousButtonTapped: headerView.rx.previousButtonTapped,
                                             nextButtonTapped: headerView.rx.nextButtonTapped,
                                             addButtonTapped: scheduleView.rx.addButtonTapped,
-                                            selectedDate: calendarView.rx.selectedDate
+                                            selectedDate: calendarView.rx.selectedDate,
+                                            tableViewItemDelted: scheduleView.scheduleTableView.rx.itemDeleted
         )
         
         let output = viewModel.transform(input: input)
@@ -89,6 +90,7 @@ private extension CalendarViewController {
             .drive { owner, date in
                 owner.calendarView.changeCurrentPage(date)
                 owner.headerView.configureHeaderView(date)
+                owner.fetchTrigger.accept(())
             }
             .disposed(by: disposeBag)
         
@@ -110,13 +112,14 @@ private extension CalendarViewController {
             .drive { owner, data in
                 let isEmpty = data.first?.items.isEmpty ?? true
                 owner.scheduleView.updateTableViewSize(isEmpty)
-                if !isEmpty {
+                
+                if isEmpty {
                     owner.scheduleView.snp.updateConstraints {
-                        $0.height.equalTo(self.scheduleView.scheduleTableView.contentSize.height + 60)
+                        $0.height.equalTo(100)
                     }
                 } else {
                     owner.scheduleView.snp.updateConstraints {
-                        $0.height.equalTo(100)
+                        $0.height.equalTo(owner.scheduleView.scheduleTableView.contentSize.height + 60)
                     }
                 }
             }

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
@@ -1,0 +1,126 @@
+//
+//  CalendarViewController.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/11/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class CalendarViewController: UIViewController {
+    
+    private var disposeBag = DisposeBag()
+    private let fetchTrigger = PublishRelay<Void>()
+    
+    private let viewModel = CalendarViewModel()
+    
+    private let headerView = CalendarHeaderView()
+    private let calendarView = CalendarView()
+    private let scheduleView = ScheduleView()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        setupUI()
+        fetchTrigger.accept(())
+    }
+    
+}
+
+private extension CalendarViewController {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+        bind()
+    }
+    
+    func configureSelf() {
+        view.backgroundColor = .Personal.backgroundPink
+        [headerView, calendarView, scheduleView].forEach {
+            view.addSubview($0)
+        }
+    }
+    
+    func setupLayout() {
+        headerView.snp.makeConstraints {
+            $0.top.equalToSuperview()
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(60)
+        }
+        
+        calendarView.snp.makeConstraints {
+            $0.top.equalTo(headerView.snp.bottom).offset(8)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(336) // TODO: 스케줄 리스트 뷰 구현 후 수정
+        }
+        
+        scheduleView.snp.makeConstraints {
+            $0.top.equalTo(calendarView.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(100) // TODO: 동적으로 변하도록 수정
+        }
+    }
+    
+    func bind() {
+        let input = CalendarViewModel.Input(fetchTrigger: fetchTrigger,
+                                            previousButtonTapped: headerView.rx.previousButtonTapped,
+                                            nextButtonTapped: headerView.rx.nextButtonTapped,
+                                            addButtonTapped: scheduleView.rx.addButtonTapped,
+                                            selectedDate: calendarView.rx.selectedDate
+        )
+        
+        let output = viewModel.transform(input: input)
+        
+        output.eventsRelay
+            .withUnretained(self)
+            .asSignal(onErrorSignalWith: .empty())
+            .emit { owner, events in
+                owner.calendarView.setupEvents(events)
+            }
+            .disposed(by: disposeBag)
+        
+        output.changeCurrentDatePage
+            .withUnretained(self)
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { owner, date in
+                owner.calendarView.changeCurrentPage(date)
+                owner.headerView.configureHeaderView(date)
+            }
+            .disposed(by: disposeBag)
+        
+        output.selectedDate
+            .withUnretained(self)
+            .asSignal(onErrorSignalWith: .empty())
+            .emit { owner, date in
+                owner.scheduleView.configureTitleDate(date)
+            }
+            .disposed(by: disposeBag)
+        
+        output.scheduleSection
+            .bind(to: scheduleView.scheduleTableView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+        
+        output.scheduleSection
+            .withUnretained(self)
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { owner, data in
+                let isEmpty = data.first?.items.isEmpty ?? true
+                owner.scheduleView.updateTableViewSize(isEmpty)
+                if !isEmpty {
+                    owner.scheduleView.snp.updateConstraints {
+                        $0.height.equalTo(self.scheduleView.scheduleTableView.contentSize.height + 60)
+                    }
+                } else {
+                    owner.scheduleView.snp.updateConstraints {
+                        $0.height.equalTo(100)
+                    }
+                }
+            }
+            .disposed(by: disposeBag)
+    }
+    
+}

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
@@ -71,7 +71,7 @@ private extension CalendarViewController {
                                             nextButtonTapped: headerView.rx.nextButtonTapped,
                                             addButtonTapped: scheduleView.rx.addButtonTapped,
                                             selectedDate: calendarView.rx.selectedDate,
-                                            tableViewItemDelted: scheduleView.scheduleTableView.rx.itemDeleted,
+                                            tableViewItemDeleted: scheduleView.scheduleTableView.rx.itemDeleted,
                                             tableViewItemEdited: scheduleView.scheduleTableView.rx.itemSelected
         )
         

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
@@ -71,7 +71,8 @@ private extension CalendarViewController {
                                             nextButtonTapped: headerView.rx.nextButtonTapped,
                                             addButtonTapped: scheduleView.rx.addButtonTapped,
                                             selectedDate: calendarView.rx.selectedDate,
-                                            tableViewItemDelted: scheduleView.scheduleTableView.rx.itemDeleted
+                                            tableViewItemDelted: scheduleView.scheduleTableView.rx.itemDeleted,
+                                            tableViewItemEdited: scheduleView.scheduleTableView.rx.itemSelected
         )
         
         let output = viewModel.transform(input: input)

--- a/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/CalendarViewController.swift
@@ -10,16 +10,25 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+/// 캘린더 뷰 컨트롤러
 final class CalendarViewController: UIViewController {
+    
+    // MARK: - Rx Properties
     
     private var disposeBag = DisposeBag()
     private let fetchTrigger = PublishRelay<Void>()
     
+    // MARK: - Properties
+    
     private let viewModel = CalendarViewModel()
+    
+    // MARK: - UI Components
     
     private let headerView = CalendarHeaderView()
     private let calendarView = CalendarView()
     private let scheduleView = ScheduleView()
+    
+    // MARK: - LifeCycle
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -29,6 +38,8 @@ final class CalendarViewController: UIViewController {
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension CalendarViewController {
     
@@ -77,6 +88,7 @@ private extension CalendarViewController {
         
         let output = viewModel.transform(input: input)
         
+        // 캘린더 이벤트 설정
         output.eventsRelay
             .withUnretained(self)
             .asSignal(onErrorSignalWith: .empty())
@@ -85,6 +97,7 @@ private extension CalendarViewController {
             }
             .disposed(by: disposeBag)
         
+        // 캘린더 페이지 변경
         output.changeCurrentDatePage
             .withUnretained(self)
             .asDriver(onErrorDriveWith: .empty())
@@ -95,6 +108,7 @@ private extension CalendarViewController {
             }
             .disposed(by: disposeBag)
         
+        // 캘린더 스케줄 뷰 타이틀 변경
         output.selectedDate
             .withUnretained(self)
             .asSignal(onErrorSignalWith: .empty())
@@ -103,10 +117,12 @@ private extension CalendarViewController {
             }
             .disposed(by: disposeBag)
         
+        // 캘린더 스케줄 뷰 섹션 변경
         output.scheduleSection
             .bind(to: scheduleView.scheduleTableView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
         
+        // 캘린더 스케줄 뷰 사이즈 변경
         output.scheduleSection
             .withUnretained(self)
             .asDriver(onErrorDriveWith: .empty())

--- a/Lovechive/Lovechive/Source/View/CalendarView/ScheduleView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/ScheduleView.swift
@@ -10,12 +10,17 @@ import SnapKit
 import RxSwift
 import RxCocoa
 
+/// 캘린더 스케줄 뷰
 final class ScheduleView: UIView {
+    
+    // MARK: - UI Components
     
     private let titleView = UILabel()
     fileprivate let addButton = UIButton()
     private let infoLabel = UILabel()
     private(set) var scheduleTableView = UITableView()
+    
+    // MARK: - Initializer
     
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -27,10 +32,14 @@ final class ScheduleView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
     
+    /// 타이틀을 설정하는 메소드
+    /// - Parameter date: 타이틀로 설정할 날짜 데이터
     func configureTitleDate(_ date: Date) {
-        titleView.text = date.formattedDateToString(.yearMonthDayHourMinute)
+        titleView.text = date.formattedDateToString(.monthDay)
     }
     
+    /// 스케줄뷰의 사이즈를 업데이트 하는 메소드
+    /// - Parameter isEmpty: 섹션 아이템의 존재 여부
     func updateTableViewSize(_ isEmpty: Bool) {
         if isEmpty {
             infoLabel.isHidden = false
@@ -45,6 +54,8 @@ final class ScheduleView: UIView {
         }
     }
 }
+
+// MARK: - UI Setting Method
 
 private extension ScheduleView {
     
@@ -125,7 +136,10 @@ private extension ScheduleView {
     
 }
 
+// MARK: - Reactive Extension
+
 extension Reactive where Base: ScheduleView {
+    /// 만들기 버튼의 탭 이벤트를 방출하는 옵저버블
     var addButtonTapped: ControlEvent<Void> {
         base.addButton.rx.tap
     }

--- a/Lovechive/Lovechive/Source/View/CalendarView/ScheduleView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/ScheduleView.swift
@@ -1,0 +1,132 @@
+//
+//  ScheduleView.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/11/25.
+//
+
+import UIKit
+import SnapKit
+import RxSwift
+import RxCocoa
+
+final class ScheduleView: UIView {
+    
+    private let titleView = UILabel()
+    fileprivate let addButton = UIButton()
+    private let infoLabel = UILabel()
+    private(set) var scheduleTableView = UITableView()
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    func configureTitleDate(_ date: Date) {
+        titleView.text = date.formattedDateToSchedule()
+    }
+    
+    func updateTableViewSize(_ isEmpty: Bool) {
+        if isEmpty {
+            infoLabel.isHidden = false
+            scheduleTableView.isHidden = true
+        } else {
+            infoLabel.isHidden = true
+            scheduleTableView.isHidden = false
+            scheduleTableView.layoutIfNeeded()
+            scheduleTableView.snp.updateConstraints {
+                $0.height.equalTo(scheduleTableView.contentSize.height)
+            }
+        }
+    }
+}
+
+private extension ScheduleView {
+    
+    func setupUI() {
+        setupTitle()
+        setupInfoLabel()
+        setupButton()
+        setupTableView()
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        backgroundColor = .white
+        layer.cornerRadius = 16
+        [titleView, addButton, infoLabel, scheduleTableView].forEach {
+            addSubview($0)
+        }
+    }
+    
+    func setupLayout() {
+        titleView.snp.makeConstraints {
+            $0.top.leading.equalToSuperview().inset(16)
+            $0.width.equalTo(200).priority(.high)
+            $0.height.equalTo(28)
+        }
+        
+        addButton.snp.makeConstraints {
+            $0.top.trailing.equalToSuperview().inset(16)
+            $0.width.height.equalTo(28)
+        }
+        
+        infoLabel.snp.makeConstraints {
+            $0.top.equalTo(titleView.snp.bottom).offset(8)
+            $0.bottom.horizontalEdges.equalToSuperview().inset(16)
+        }
+        
+        scheduleTableView.snp.makeConstraints {
+            $0.top.equalTo(titleView.snp.bottom).offset(4)
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(28)
+        }
+    }
+    
+    func setupTitle() {
+        titleView.text = AppConfig.CalendarViewConfig.title
+        titleView.textColor = .Personal.highlightPink
+        titleView.font = .systemFont(ofSize: 16, weight: .bold)
+        titleView.numberOfLines = 1
+        titleView.textAlignment = .left
+        titleView.backgroundColor = .clear
+    }
+    
+    func setupInfoLabel() {
+        infoLabel.text = AppConfig.CalendarViewConfig.info
+        infoLabel.textColor = .Gray.unSelected
+        infoLabel.font = .systemFont(ofSize: 14, weight: .regular)
+        infoLabel.numberOfLines = 1
+        infoLabel.textAlignment = .left
+        infoLabel.backgroundColor = .clear
+    }
+    
+    func setupButton() {
+        addButton.setImage(UIImage(systemName: "plus"), for: .normal)
+        addButton.tintColor = .Personal.highlightPink
+        addButton.backgroundColor = .clear
+    }
+    
+    func setupTableView() {
+        scheduleTableView.rowHeight = 36 // 기본 높이 설정
+        scheduleTableView.backgroundColor = .clear
+        scheduleTableView.separatorStyle = .none
+        scheduleTableView.isScrollEnabled = false
+        scheduleTableView.showsVerticalScrollIndicator = false
+        scheduleTableView.showsHorizontalScrollIndicator = false
+        scheduleTableView.register(ScheduleViewCell.self, forCellReuseIdentifier: AppConfig.CalendarViewConfig.cellId)
+    }
+    
+}
+
+extension Reactive where Base: ScheduleView {
+    var addButtonTapped: ControlEvent<Void> {
+        base.addButton.rx.tap
+    }
+}

--- a/Lovechive/Lovechive/Source/View/CalendarView/ScheduleView.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/ScheduleView.swift
@@ -28,7 +28,7 @@ final class ScheduleView: UIView {
     }
     
     func configureTitleDate(_ date: Date) {
-        titleView.text = date.formattedDateToSchedule()
+        titleView.text = date.formattedDateToString(.yearMonthDayHourMinute)
     }
     
     func updateTableViewSize(_ isEmpty: Bool) {

--- a/Lovechive/Lovechive/Source/View/CalendarView/ScheduleViewCell.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/ScheduleViewCell.swift
@@ -1,0 +1,81 @@
+//
+//  ScheduleViewCell.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/11/25.
+//
+
+import UIKit
+import SnapKit
+
+final class ScheduleViewCell: UITableViewCell {
+    
+    private lazy var timeLabel = createdLabel(title: AppConfig.CalendarViewConfig.cellDate, color: .Gray.unSelected, size: 14)
+    private lazy var titleLabel = createdLabel(title: AppConfig.CalendarViewConfig.cellTitle, color: .Gray.naturalBlack, size: 16)
+    
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        
+        setupUI()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        
+        reusedCell()
+    }
+    
+    func configureCell(time: Date, title: String) {
+        timeLabel.text = time.formattedDateToScheduleTime()
+        titleLabel.text = title
+    }
+    
+}
+
+private extension ScheduleViewCell {
+    
+    func setupUI() {
+        configureSelf()
+        setupLayout()
+    }
+    
+    func configureSelf() {
+        backgroundColor = .clear
+        [timeLabel, titleLabel].forEach {
+            addSubview($0)
+        }
+    }
+    
+    func setupLayout() {
+        timeLabel.snp.makeConstraints {
+            $0.leading.verticalEdges.equalToSuperview()
+            $0.width.equalTo(100)
+        }
+        
+        titleLabel.snp.makeConstraints {
+            $0.leading.equalTo(timeLabel.snp.trailing)
+            $0.verticalEdges.trailing.equalToSuperview()
+        }
+    }
+    
+    func reusedCell() {
+        timeLabel.text = ""
+        titleLabel.text = ""
+    }
+    
+    func createdLabel(title: String, color: UIColor, size: CGFloat) -> UILabel {
+        let label = UILabel()
+        label.text = title
+        label.font = .systemFont(ofSize: size, weight: .regular)
+        label.textColor = color
+        label.numberOfLines = 1
+        label.textAlignment = .left
+        
+        return label
+    }
+    
+}

--- a/Lovechive/Lovechive/Source/View/CalendarView/ScheduleViewCell.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/ScheduleViewCell.swift
@@ -30,7 +30,7 @@ final class ScheduleViewCell: UITableViewCell {
     }
     
     func configureCell(time: Date, title: String) {
-        timeLabel.text = time.formattedDateToScheduleTime()
+        timeLabel.text = time.formattedDateToString(.hourMinute)
         titleLabel.text = title
     }
     

--- a/Lovechive/Lovechive/Source/View/CalendarView/ScheduleViewCell.swift
+++ b/Lovechive/Lovechive/Source/View/CalendarView/ScheduleViewCell.swift
@@ -8,10 +8,15 @@
 import UIKit
 import SnapKit
 
+/// 캘린더 스케줄뷰 커스텀 셀
 final class ScheduleViewCell: UITableViewCell {
+    
+    // MARK: - UI Components
     
     private lazy var timeLabel = createdLabel(title: AppConfig.CalendarViewConfig.cellDate, color: .Gray.unSelected, size: 14)
     private lazy var titleLabel = createdLabel(title: AppConfig.CalendarViewConfig.cellTitle, color: .Gray.naturalBlack, size: 16)
+    
+    // MARK: - Initializer
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
@@ -23,18 +28,25 @@ final class ScheduleViewCell: UITableViewCell {
         fatalError("init(coder:) has not been implemented")
     }
     
+    // 셀 재사용 옵션
     override func prepareForReuse() {
         super.prepareForReuse()
         
         reusedCell()
     }
     
+    /// 셀을 설정하는 메소드
+    /// - Parameters:
+    ///   - time: 설정할 시간
+    ///   - title: 설정할 타이틀
     func configureCell(time: Date, title: String) {
         timeLabel.text = time.formattedDateToString(.hourMinute)
         titleLabel.text = title
     }
     
 }
+
+// MARK: - UI Setting Method
 
 private extension ScheduleViewCell {
     

--- a/Lovechive/Lovechive/Source/View/MainPageView/DDayView.swift
+++ b/Lovechive/Lovechive/Source/View/MainPageView/DDayView.swift
@@ -36,7 +36,7 @@ final class DDayView: UIView {
     func configureDDayView(_ date: Date) {
         let dDay = Calendar.current.dateComponents([.day], from: date, to: Date()).day
         dDayView.text = "D + \(dDay ?? 0)"
-        infoLabel.text = date.formattedDate()
+        infoLabel.text = "\(date.formattedDateToString(.yearMonthDay))부터"
     }
     
 }

--- a/Lovechive/Lovechive/Source/View/MainPageView/LatestDiaryView.swift
+++ b/Lovechive/Lovechive/Source/View/MainPageView/LatestDiaryView.swift
@@ -38,7 +38,7 @@ final class LatestDiaryView: UIView {
     ///   - image: 일기의 이미지 경로
     func configureView(content: String, date: Date, image: String) {
         contentView.text = content
-        dateView.text = date.formattedDateAndTime()
+        dateView.text = date.formattedDateToString(.yearMonthDayHourMinute)
         imageView.image = ImageManager.shared.loadImage(path: image) == nil ? .no : ImageManager.shared.loadImage(path: image)
     }
     

--- a/Lovechive/Lovechive/Source/View/MainPageView/MainPageScrollView.swift
+++ b/Lovechive/Lovechive/Source/View/MainPageView/MainPageScrollView.swift
@@ -63,7 +63,7 @@ private extension MainPageScrollView {
         }
         
         contentView.snp.makeConstraints {
-            $0.top.horizontalEdges.equalToSuperview()
+            $0.edges.equalToSuperview()
             $0.width.equalToSuperview()
         }
         
@@ -115,6 +115,7 @@ private extension MainPageScrollView {
             planerView.snp.updateConstraints {
                 $0.height.equalTo(tableHeight + 50)
             }
+            contentsScrollView.contentSize.height = 516
         }
     }
 

--- a/Lovechive/Lovechive/Source/View/MainPageView/MainPageViewController.swift
+++ b/Lovechive/Lovechive/Source/View/MainPageView/MainPageViewController.swift
@@ -22,7 +22,6 @@ final class MainPageViewController: UIViewController {
     
     // MARK: - UI Components
     
-    private let logoView = LogoView()
     private let contentsView = MainPageScrollView()
         
     // MARK: - VC LifeCycle
@@ -48,20 +47,12 @@ private extension MainPageViewController {
     
     func configureSelf() {
         view.backgroundColor = .Personal.backgroundPink
-        [logoView, contentsView].forEach {
-            view.addSubview($0)
-        }
+        view.addSubview(contentsView)
     }
 
     func setupLayout() {
-        logoView.snp.makeConstraints {
-            $0.top.horizontalEdges.equalTo(view.safeAreaLayoutGuide)
-            $0.height.equalTo(40)
-        }
-        
         contentsView.snp.makeConstraints {
-            $0.top.equalTo(logoView.snp.bottom).offset(16)
-            $0.bottom.horizontalEdges.equalToSuperview()
+            $0.edges.equalToSuperview()
         }
     }
     

--- a/Lovechive/Lovechive/Source/View/MainPageView/PlanViewCell.swift
+++ b/Lovechive/Lovechive/Source/View/MainPageView/PlanViewCell.swift
@@ -42,7 +42,7 @@ final class PlanViewCell: UITableViewCell {
     ///   - date: 일정의 Date
     func configureCell(title: String, date: Date) {
         titleView.text = title
-        dateView.text = date.formattedDateAndTime()
+        dateView.text = date.formattedDateToString(.yearMonthDayHourMinute)
     }
 }
 

--- a/Lovechive/Lovechive/Source/View/MainViewController.swift
+++ b/Lovechive/Lovechive/Source/View/MainViewController.swift
@@ -76,7 +76,7 @@ private extension MainViewController {
         
         let selectedVC = pages[index]
         
-        UIView.transition(with: view, duration: 0.5, options: .transitionCrossDissolve) {
+        UIView.transition(with: view, duration: 0.3, options: .transitionCrossDissolve) {
             self.addChild(selectedVC)
             self.view.addSubview(selectedVC.view)
             

--- a/Lovechive/Lovechive/Source/View/MainViewController.swift
+++ b/Lovechive/Lovechive/Source/View/MainViewController.swift
@@ -21,6 +21,8 @@ final class MainViewController: UIViewController {
     // MARK: - UI Components
     
     private let tabBarView = TabBarView()
+    private let logoView = LogoView()
+    private let backgroundView = UIView()
     private let currentPageViewController = PageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
 
     // MARK: - VC LifeCycle
@@ -44,6 +46,7 @@ final class MainViewController: UIViewController {
 private extension MainViewController {
     
     func setupUI() {
+        setupBackgroundView()
         configureSelf()
         setupLayout()
         setupChildViewController()
@@ -52,7 +55,7 @@ private extension MainViewController {
     
     func configureSelf() {
         view.backgroundColor = .white
-        [tabBarView].forEach {
+        [backgroundView, logoView, tabBarView].forEach {
             view.addSubview($0)
         }
     }
@@ -62,19 +65,36 @@ private extension MainViewController {
         addChild(currentPageViewController)
         view.addSubview(currentPageViewController.view)
         currentPageViewController.view.snp.makeConstraints {
-            $0.top.horizontalEdges.equalToSuperview()
+            $0.top.equalTo(logoView.snp.bottom).offset(16)
+            $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(tabBarView.snp.top)
         }
         currentPageViewController.didMove(toParent: self)
         view.bringSubviewToFront(tabBarView)
+        view.bringSubviewToFront(logoView)
     }
     
     func setupLayout() {
+        backgroundView.snp.makeConstraints {
+            $0.top.horizontalEdges.equalToSuperview()
+            $0.bottom.equalTo(view.safeAreaLayoutGuide).inset(64)
+        }
+        
+        logoView.snp.makeConstraints {
+            $0.top.equalTo(view.safeAreaLayoutGuide)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(40)
+        }
+        
         tabBarView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview()
             $0.bottom.equalTo(view.safeAreaLayoutGuide)
             $0.height.equalTo(64)
         }
+    }
+    
+    func setupBackgroundView() {
+        backgroundView.backgroundColor = .Personal.backgroundPink
     }
     
     /// 데이터 바인딩 메소드

--- a/Lovechive/Lovechive/Source/View/MainViewController.swift
+++ b/Lovechive/Lovechive/Source/View/MainViewController.swift
@@ -18,12 +18,19 @@ final class MainViewController: UIViewController {
     private let viewModel = MainViewModel()
     private var disposeBag = DisposeBag()
     
+    private let pages: [UIViewController] = [
+        MainPageViewController(),
+        CalendarViewController(),
+        TestDiaryViewController(),
+        TestSettingViewController()
+    ]
+    
     // MARK: - UI Components
     
     private let tabBarView = TabBarView()
     private let logoView = LogoView()
     private let backgroundView = UIView()
-    private let currentPageViewController = PageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
+    private var currentPageViewController: UIViewController?
 
     // MARK: - VC LifeCycle
     
@@ -49,7 +56,7 @@ private extension MainViewController {
         setupBackgroundView()
         configureSelf()
         setupLayout()
-        setupChildViewController()
+        setupChildViewController(0)
         bind()
     }
     
@@ -61,17 +68,30 @@ private extension MainViewController {
     }
     
     /// 서브 뷰 컨트롤러를 설정하는 메소드
-    func setupChildViewController() {
-        addChild(currentPageViewController)
-        view.addSubview(currentPageViewController.view)
-        currentPageViewController.view.snp.makeConstraints {
-            $0.top.equalTo(logoView.snp.bottom).offset(16)
-            $0.horizontalEdges.equalToSuperview()
-            $0.bottom.equalTo(tabBarView.snp.top)
+    func setupChildViewController(_ index: Int) {
+        if let currentVC = self.currentPageViewController {
+            currentVC.view.removeFromSuperview()
+            currentVC.removeFromParent()
         }
-        currentPageViewController.didMove(toParent: self)
-        view.bringSubviewToFront(tabBarView)
-        view.bringSubviewToFront(logoView)
+        
+        let selectedVC = pages[index]
+        
+        UIView.transition(with: view, duration: 0.5, options: .transitionCrossDissolve) {
+            self.addChild(selectedVC)
+            self.view.addSubview(selectedVC.view)
+            
+            selectedVC.view.snp.makeConstraints {
+                $0.top.equalTo(self.logoView.snp.bottom).offset(16)
+                $0.horizontalEdges.equalToSuperview()
+                $0.bottom.equalTo(self.tabBarView.snp.top)
+            }
+            
+            selectedVC.didMove(toParent: self)
+            self.currentPageViewController = selectedVC
+            
+            self.view.bringSubviewToFront(self.tabBarView)
+            self.view.bringSubviewToFront(self.logoView)
+        }
     }
     
     func setupLayout() {
@@ -102,8 +122,8 @@ private extension MainViewController {
         let input = MainViewModel.Input(firstButtonTapped: tabBarView.rx.firstButtonTapped,
                                         secondButtonTapped: tabBarView.rx.secondButtonTapped,
                                         thirdButtonTapped: tabBarView.rx.thirdButtonTapped,
-                                        forthButtonTapped: tabBarView.rx.forthButtonTapped,
-                                        changedPage: currentPageViewController.rx.currentPage)
+                                        forthButtonTapped: tabBarView.rx.forthButtonTapped
+        )
         
         let output = viewModel.transform(input: input)
         
@@ -111,16 +131,9 @@ private extension MainViewController {
         output.changedCurretPage
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] state in
-                self?.currentPageViewController.changePage(to: state) {
-                    self?.tabBarView.changeButtonState(state: state)
-                }
-            }.disposed(by: disposeBag)
-        
-        // 페이지를 스와이프 했을 때 해당 페이지로 이동하는 이벤트
-        output.scrollToPage
-            .asDriver(onErrorDriveWith: .empty())
-            .drive { [weak self] state in
-                self?.tabBarView.changeButtonState(state: state)
+                guard let self, let index = TabBarButtonState.allCases.firstIndex(of: state) else { return }
+                self.setupChildViewController(index)
+                self.tabBarView.changeButtonState(state: state)
             }.disposed(by: disposeBag)
     }
 }

--- a/Lovechive/Lovechive/Source/View/MainViewController.swift
+++ b/Lovechive/Lovechive/Source/View/MainViewController.swift
@@ -18,6 +18,8 @@ final class MainViewController: UIViewController {
     private let viewModel = MainViewModel()
     private var disposeBag = DisposeBag()
     
+    // MARK: - Properties
+    
     private let pages: [UIViewController] = [
         MainPageViewController(),
         CalendarViewController(),

--- a/Lovechive/Lovechive/Source/View/MainViewController.swift
+++ b/Lovechive/Lovechive/Source/View/MainViewController.swift
@@ -111,8 +111,9 @@ private extension MainViewController {
         output.changedCurretPage
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] state in
-                self?.tabBarView.changeButtonState(state: state)
-                self?.currentPageViewController.changePage(to: state)
+                self?.currentPageViewController.changePage(to: state) {
+                    self?.tabBarView.changeButtonState(state: state)
+                }
             }.disposed(by: disposeBag)
         
         // 페이지를 스와이프 했을 때 해당 페이지로 이동하는 이벤트

--- a/Lovechive/Lovechive/Source/View/PageView/PageViewController.swift
+++ b/Lovechive/Lovechive/Source/View/PageView/PageViewController.swift
@@ -27,6 +27,8 @@ final class PageViewController: UIPageViewController {
         TestSettingViewController()
     ]
     
+    private var isScrolling: Bool = false
+    
     // MARK: - VC LifeCycle
     
     override func viewDidLoad() {
@@ -40,14 +42,21 @@ final class PageViewController: UIPageViewController {
     
     /// 현재 보여지는 페이지를 변경하는 메소드
     /// - Parameter state: 변경할 페이지의 state
-    func changePage(to state: TabBarButtonState) {
-        let index = Int(TabBarButtonState.allCases.firstIndex(of: state) ?? 0)
-        guard let currentVC = viewControllers?.first,
+    func changePage(to state: TabBarButtonState, _ completion: @escaping () -> Void) {
+        guard !isScrolling,
+              let index = TabBarButtonState.allCases.firstIndex(of: state),
+              index < pages.count,
+              let currentVC = viewControllers?.first,
               let currentIndex = pages.firstIndex(of: currentVC),
               index != currentIndex else { return }
         
+        isScrolling = true
+        
         let direction: UIPageViewController.NavigationDirection = (index > currentIndex) ? .forward : .reverse
-        setViewControllers([pages[index]], direction: direction, animated: true, completion: nil)
+        setViewControllers([pages[index]], direction: direction, animated: true) { completed in
+            self.isScrolling = false
+            completion()
+        }
     }
 }
 

--- a/Lovechive/Lovechive/Source/View/PageView/PageViewController.swift
+++ b/Lovechive/Lovechive/Source/View/PageView/PageViewController.swift
@@ -22,7 +22,7 @@ final class PageViewController: UIPageViewController {
     
     private let pages: [UIViewController] = [
         MainPageViewController(),
-        TestCalendarViewController(),
+        CalendarViewController(),
         TestDiaryViewController(),
         TestSettingViewController()
     ]
@@ -90,12 +90,6 @@ extension Reactive where Base: PageViewController {
 
 // MARK: - TestViewControllers
 
-final class TestCalendarViewController: UIViewController {
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        view.backgroundColor = .blue
-    }
-}
 final class TestDiaryViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
@@ -19,7 +19,7 @@ final class CalendarViewModel: ViewModelType {
         let nextButtonTapped: ControlEvent<Void>
         let addButtonTapped: ControlEvent<Void>
         let selectedDate: BehaviorRelay<Date>
-        let tableViewItemDelted: ControlEvent<IndexPath>
+        let tableViewItemDeleted: ControlEvent<IndexPath>
         let tableViewItemEdited: ControlEvent<IndexPath>
     }
     
@@ -134,7 +134,7 @@ final class CalendarViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
-        input.tableViewItemDelted
+        input.tableViewItemDeleted
             .withUnretained(self)
             .map { owner, indexPath in
                 owner.searchItemId(indexPath).id

--- a/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
@@ -5,7 +5,8 @@
 //  Created by 장상경 on 3/11/25.
 //
 
-import Foundation
+import UIKit
+import SnapKit
 import RxSwift
 import RxCocoa
 import FirebaseFirestore
@@ -90,6 +91,20 @@ final class CalendarViewModel: ViewModelType {
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] data in
                 self?.scheduleSection.accept(data)
+            }
+            .disposed(by: disposeBag)
+        
+        input.addButtonTapped
+            .asSignal(onErrorSignalWith: .empty())
+            .emit { _ in
+                let vc = AppHelpers.getTopViewController()
+                let alert = LovechiveAlertViewController(type: .newSchedule)
+                vc?.addChild(alert)
+                vc?.view.addSubview(alert.view)
+                alert.view.snp.makeConstraints {
+                    $0.edges.equalToSuperview()
+                }
+                alert.didMove(toParent: vc)
             }
             .disposed(by: disposeBag)
         

--- a/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
@@ -19,6 +19,7 @@ final class CalendarViewModel: ViewModelType {
         let nextButtonTapped: ControlEvent<Void>
         let addButtonTapped: ControlEvent<Void>
         let selectedDate: BehaviorRelay<Date>
+        let tableViewItemDelted: ControlEvent<IndexPath>
     }
     
     struct Output {
@@ -29,6 +30,9 @@ final class CalendarViewModel: ViewModelType {
     }
     
     private var disposeBag = DisposeBag()
+    
+    private var sections: [ScheduleModelSection] = []
+    private var queryDatas: [QueryDocumentSnapshot] = []
     
     private let changeCurrentDatePage = BehaviorRelay<Date>(value: Date())
     private let selectedDate = BehaviorRelay<Date>(value: Date())
@@ -44,11 +48,24 @@ final class CalendarViewModel: ViewModelType {
             }
             .map { [weak self] data in
                 guard let self else { return [Date]() }
-                return mappingScheduleDataToEventDates(data)
+                return self.mappingScheduleDataToEventDates(data)
             }
             .asDriver(onErrorDriveWith: .empty())
             .drive { [weak self] dates in
                 self?.eventsRelay.accept(dates)
+            }
+            .disposed(by: disposeBag)
+        
+        eventsRelay
+            .withUnretained(self)
+            .compactMap { owner, data in
+                return owner.filteredToDayDateToScheduleSection(owner.eventsRelay.value, owner.queryDatas)
+            }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { [weak self] datas in
+                guard let self else { return }
+                self.sections = datas
+                self.selectedDate.accept(self.selectedDate.value)
             }
             .disposed(by: disposeBag)
         
@@ -80,11 +97,8 @@ final class CalendarViewModel: ViewModelType {
         
         selectedDate
             .withUnretained(self)
-            .flatMap { owner, _ in owner.fetchDate() }
-            .map { [weak self] query in
-                guard let self else { return [ScheduleModelSection]() }
-                let date = self.selectedDate.value
-                let data = self.filteredToDayDateToScheduleSection(date, query)
+            .map { owner, date in
+                let data = owner.filteredSection(date)
                 
                 return [data]
             }
@@ -95,16 +109,38 @@ final class CalendarViewModel: ViewModelType {
             .disposed(by: disposeBag)
         
         input.addButtonTapped
+            .withUnretained(self)
+            .flatMap { owner, _ in
+                owner.showAlertView()
+            }
             .asSignal(onErrorSignalWith: .empty())
             .emit { _ in
-                let vc = AppHelpers.getTopViewController()
-                let alert = LovechiveAlertViewController(type: .newSchedule)
-                vc?.addChild(alert)
-                vc?.view.addSubview(alert.view)
-                alert.view.snp.makeConstraints {
-                    $0.edges.equalToSuperview()
+                input.fetchTrigger.accept(())
+            }
+            .disposed(by: disposeBag)
+        
+        input.tableViewItemDelted
+            .withUnretained(self)
+            .map { owner, indexPath in
+                let section = owner.sections.filter {
+                    Calendar.current.isDate($0.items.first?.date ?? Date(), inSameDayAs: owner.selectedDate.value)
+                }.first
+                
+                let index = owner.sections.firstIndex { sectionData in
+                    sectionData.identity == section?.identity
                 }
-                alert.didMove(toParent: vc)
+                
+                guard let index else { return "0" }
+                
+                let item = owner.sections[index].items.remove(at: indexPath.row)
+                return item.id
+            }
+            .flatMap {
+                FirestoreManager.shared.deleteFromFirestore(type: .schedule(id: $0))
+            }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { _ in
+                input.fetchTrigger.accept(())
             }
             .disposed(by: disposeBag)
         
@@ -118,14 +154,16 @@ final class CalendarViewModel: ViewModelType {
         return FirestoreManager.shared.readFromFirestore(type: .schedule(id: ""))
     }
     
-    private func filteredToDayDateToScheduleSection(_ date: Date, _ query: [QueryDocumentSnapshot]) -> ScheduleModelSection {
-        let filteredData = query.filter {
-            let dataDate = ($0.data()[AppConfig.SchedulesModel.date] as? Timestamp)?.dateValue() ?? Date()
+    private func filteredToDayDateToScheduleSection(_ dates: [Date], _ query: [QueryDocumentSnapshot]) -> [ScheduleModelSection] {
+        let filteredData = query.filter { item in
+            let itemDate = (item.data()[AppConfig.SchedulesModel.date] as? Timestamp)?.dateValue() ?? Date()
             
-            return Calendar.current.isDate(date, inSameDayAs: dataDate)
+            return dates.contains { date in
+                Calendar.current.isDate(date, inSameDayAs: itemDate)
+            }
         }.map {
             ScheduleDataModel(
-                id: $0.data()[AppConfig.SchedulesModel.id] as? String ?? "",
+                id: $0.data()[AppConfig.SchedulesModel.id] as? String ?? UUID().uuidString,
                 title: $0.data()[AppConfig.SchedulesModel.title] as? String ?? "",
                 coupleId: $0.data()[AppConfig.SchedulesModel.coupleId] as? String ?? "",
                 date: ($0.data()[AppConfig.SchedulesModel.date] as? Timestamp)?.dateValue() ?? Date(),
@@ -134,19 +172,54 @@ final class CalendarViewModel: ViewModelType {
         }.sorted(by: {
             $0.date < $1.date
         })
+            
+        let groupedDate = Dictionary(grouping: filteredData) { item in
+            return Calendar.current.startOfDay(for: item.date)
+        }
         
-        let section = ScheduleModelSection(items: filteredData)
-        
-        return section
+        let sections = groupedDate.values.map {
+            ScheduleModelSection(items: $0)
+        }.sorted(by: {
+            $0.items.first?.date ?? Date() < $1.items.first?.date ?? Date()
+        })
+            
+        return sections
     }
     
     private func mappingScheduleDataToEventDates(_ query: [QueryDocumentSnapshot]) -> [Date] {
+        queryDatas = query
+        
         let dates = query.map { data in
             let date = (data.data()[AppConfig.SchedulesModel.date] as? Timestamp)?.dateValue() ?? Date()
             
             return date
+        }.filter { [weak self] date in
+            Calendar.current.isDate(self!.changeCurrentDatePage.value, equalTo: date, toGranularity: .month)
         }
         
         return dates
+    }
+    
+    private func filteredSection(_ date: Date) -> ScheduleModelSection {
+        let data = sections.flatMap { section in
+            section.items.filter {
+                Calendar.current.isDate($0.date, inSameDayAs: date)
+            }
+        }
+        
+        return ScheduleModelSection(items: data)
+    }
+    
+    private func showAlertView() -> PublishRelay<Void> {
+        let vc = AppHelpers.getTopViewController()
+        let alert = LovechiveAlertViewController(type: .newSchedule(date: selectedDate.value))
+        vc?.addChild(alert)
+        vc?.view.addSubview(alert.view)
+        alert.view.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+        alert.didMove(toParent: vc)
+        
+        return alert.rx.dataSavedRelay
     }
 }

--- a/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
@@ -20,6 +20,7 @@ final class CalendarViewModel: ViewModelType {
         let addButtonTapped: ControlEvent<Void>
         let selectedDate: BehaviorRelay<Date>
         let tableViewItemDelted: ControlEvent<IndexPath>
+        let tableViewItemEdited: ControlEvent<IndexPath>
     }
     
     struct Output {
@@ -111,7 +112,21 @@ final class CalendarViewModel: ViewModelType {
         input.addButtonTapped
             .withUnretained(self)
             .flatMap { owner, _ in
-                owner.showAlertView()
+                owner.showAlertView(type: .newSchedule(date: owner.selectedDate.value))
+            }
+            .asSignal(onErrorSignalWith: .empty())
+            .emit { _ in
+                input.fetchTrigger.accept(())
+            }
+            .disposed(by: disposeBag)
+        
+        input.tableViewItemEdited
+            .withUnretained(self)
+            .map { owner, indexPath in
+                owner.searchItemId(indexPath)
+            }
+            .flatMap { [weak self] item in
+                self!.showAlertView(type: .editSchedule(data: item))
             }
             .asSignal(onErrorSignalWith: .empty())
             .emit { _ in
@@ -122,18 +137,7 @@ final class CalendarViewModel: ViewModelType {
         input.tableViewItemDelted
             .withUnretained(self)
             .map { owner, indexPath in
-                let section = owner.sections.filter {
-                    Calendar.current.isDate($0.items.first?.date ?? Date(), inSameDayAs: owner.selectedDate.value)
-                }.first
-                
-                let index = owner.sections.firstIndex { sectionData in
-                    sectionData.identity == section?.identity
-                }
-                
-                guard let index else { return "0" }
-                
-                let item = owner.sections[index].items.remove(at: indexPath.row)
-                return item.id
+                owner.searchItemId(indexPath).id
             }
             .flatMap {
                 FirestoreManager.shared.deleteFromFirestore(type: .schedule(id: $0))
@@ -210,9 +214,9 @@ final class CalendarViewModel: ViewModelType {
         return ScheduleModelSection(items: data)
     }
     
-    private func showAlertView() -> PublishRelay<Void> {
+    private func showAlertView(type: AlertTypes) -> PublishRelay<Void> {
         let vc = AppHelpers.getTopViewController()
-        let alert = LovechiveAlertViewController(type: .newSchedule(date: selectedDate.value))
+        let alert = LovechiveAlertViewController(type: type)
         vc?.addChild(alert)
         vc?.view.addSubview(alert.view)
         alert.view.snp.makeConstraints {
@@ -221,5 +225,19 @@ final class CalendarViewModel: ViewModelType {
         alert.didMove(toParent: vc)
         
         return alert.rx.dataSavedRelay
+    }
+    
+    private func searchItemId(_ indexPath: IndexPath) -> ScheduleDataModel {
+        let section = sections.filter {
+            Calendar.current.isDate($0.items.first?.date ?? Date(), inSameDayAs: selectedDate.value)
+        }.first
+        
+        let index = sections.firstIndex { sectionData in
+            sectionData.identity == section?.identity
+        }
+                
+        let item = sections[index ?? 0].items.remove(at: indexPath.row)
+        
+        return item
     }
 }

--- a/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
@@ -34,6 +34,7 @@ final class CalendarViewModel: ViewModelType {
     
     private var sections: [ScheduleModelSection] = []
     private var queryDatas: [QueryDocumentSnapshot] = []
+    private let confirmAlert = AlertManager(title: "경고", message: "정말 삭제하시겠습니까?", cancelTitle: "취소", destructiveTitle: "삭제")
     
     private let changeCurrentDatePage = BehaviorRelay<Date>(value: Date())
     private let selectedDate = BehaviorRelay<Date>(value: Date())
@@ -136,8 +137,12 @@ final class CalendarViewModel: ViewModelType {
         
         input.tableViewItemDeleted
             .withUnretained(self)
-            .map { owner, indexPath in
-                owner.searchItemId(indexPath).id
+            .flatMapLatest { owner, indexPath -> Observable<String> in
+                let itemId = owner.searchItemId(indexPath).id
+                
+                return owner.confirmAlert.showAlert(.alert)
+                    .filter { $0 }
+                    .map { _ in itemId }
             }
             .flatMap {
                 FirestoreManager.shared.deleteFromFirestore(type: .schedule(id: $0))
@@ -236,7 +241,7 @@ final class CalendarViewModel: ViewModelType {
             sectionData.identity == section?.identity
         }
                 
-        let item = sections[index ?? 0].items.remove(at: indexPath.row)
+        let item = sections[index ?? 0].items[indexPath.row]
         
         return item
     }

--- a/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/CalendarViewModel.swift
@@ -1,0 +1,137 @@
+//
+//  CalendarViewModel.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/11/25.
+//
+
+import Foundation
+import RxSwift
+import RxCocoa
+import FirebaseFirestore
+
+final class CalendarViewModel: ViewModelType {
+    
+    struct Input {
+        let fetchTrigger: PublishRelay<Void>
+        let previousButtonTapped: ControlEvent<Void>
+        let nextButtonTapped: ControlEvent<Void>
+        let addButtonTapped: ControlEvent<Void>
+        let selectedDate: BehaviorRelay<Date>
+    }
+    
+    struct Output {
+        let changeCurrentDatePage: BehaviorRelay<Date>
+        let selectedDate: BehaviorRelay<Date>
+        let scheduleSection: BehaviorRelay<[ScheduleModelSection]>
+        let eventsRelay: BehaviorRelay<[Date]>
+    }
+    
+    private var disposeBag = DisposeBag()
+    
+    private let changeCurrentDatePage = BehaviorRelay<Date>(value: Date())
+    private let selectedDate = BehaviorRelay<Date>(value: Date())
+    private let scheduleSection = BehaviorRelay<[ScheduleModelSection]>(value: [])
+    private let eventsRelay = BehaviorRelay<[Date]>(value: [])
+    
+    func transform(input: Input) -> Output {
+        
+        input.fetchTrigger
+            .withUnretained(self)
+            .flatMap { owner, _ in
+                owner.fetchDate()
+            }
+            .map { [weak self] data in
+                guard let self else { return [Date]() }
+                return mappingScheduleDataToEventDates(data)
+            }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { [weak self] dates in
+                self?.eventsRelay.accept(dates)
+            }
+            .disposed(by: disposeBag)
+        
+        input.previousButtonTapped
+            .withUnretained(self)
+            .map { owner, _ -> Date in
+                let currentDate = owner.changeCurrentDatePage.value
+                let previousDate = Calendar.current.date(byAdding: .month, value: -1, to: currentDate) ?? currentDate
+                return previousDate
+            }
+            .asObservable()
+            .bind(to: changeCurrentDatePage)
+            .disposed(by: disposeBag)
+        
+        input.nextButtonTapped
+            .withUnretained(self)
+            .map { owner, _ -> Date in
+                let currentDate = owner.changeCurrentDatePage.value
+                let nextDate = Calendar.current.date(byAdding: .month, value: 1, to: currentDate) ?? currentDate
+                return nextDate
+            }
+            .asObservable()
+            .bind(to: changeCurrentDatePage)
+            .disposed(by: disposeBag)
+        
+        input.selectedDate
+            .bind(to: selectedDate)
+            .disposed(by: disposeBag)
+        
+        selectedDate
+            .withUnretained(self)
+            .flatMap { owner, _ in owner.fetchDate() }
+            .map { [weak self] query in
+                guard let self else { return [ScheduleModelSection]() }
+                let date = self.selectedDate.value
+                let data = self.filteredToDayDateToScheduleSection(date, query)
+                
+                return [data]
+            }
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { [weak self] data in
+                self?.scheduleSection.accept(data)
+            }
+            .disposed(by: disposeBag)
+        
+        return Output(changeCurrentDatePage: changeCurrentDatePage,
+                      selectedDate: selectedDate,
+                      scheduleSection: scheduleSection,
+                      eventsRelay: eventsRelay)
+    }
+    
+    private func fetchDate() -> Single<[QueryDocumentSnapshot]> {
+        return FirestoreManager.shared.readFromFirestore(type: .schedule(id: ""))
+    }
+    
+    private func filteredToDayDateToScheduleSection(_ date: Date, _ query: [QueryDocumentSnapshot]) -> ScheduleModelSection {
+        let filteredData = query.filter {
+            let dataDate = ($0.data()[AppConfig.SchedulesModel.date] as? Timestamp)?.dateValue() ?? Date()
+            
+            return Calendar.current.isDate(date, inSameDayAs: dataDate)
+        }.map {
+            ScheduleDataModel(
+                id: $0.data()[AppConfig.SchedulesModel.id] as? String ?? "",
+                title: $0.data()[AppConfig.SchedulesModel.title] as? String ?? "",
+                coupleId: $0.data()[AppConfig.SchedulesModel.coupleId] as? String ?? "",
+                date: ($0.data()[AppConfig.SchedulesModel.date] as? Timestamp)?.dateValue() ?? Date(),
+                createdBy: $0.data()[AppConfig.SchedulesModel.createdBy] as? String ?? ""
+            )
+        }.sorted(by: {
+            $0.date < $1.date
+        })
+        
+        let section = ScheduleModelSection(items: filteredData)
+        
+        return section
+    }
+    
+    private func mappingScheduleDataToEventDates(_ query: [QueryDocumentSnapshot]) -> [Date] {
+        let dates = query.map { data in
+            let date = (data.data()[AppConfig.SchedulesModel.date] as? Timestamp)?.dateValue() ?? Date()
+            
+            return date
+        }
+        
+        return dates
+    }
+}

--- a/Lovechive/Lovechive/Source/ViewModel/LovechiveAlertViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/LovechiveAlertViewModel.swift
@@ -8,20 +8,41 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import RxKeyboard
 
 final class LovechiveAlertViewModel: ViewModelType {
     
     private var disposeBag = DisposeBag()
+    private let umd = UserDefaultsManager()
+    private let alert = AlertManager.init(title: "경고", message: "모든 내용을 입력해 주세요!!", cancelTitle: "확인")
     
     struct Input {
         let cancelButtonTapped: ControlEvent<Void>
         let activeButtonTapped: ControlEvent<Void>
-//        let scheduleTimeRelay: BehaviorRelay<Date>
-//        let scheduleTitleRelay: BehaviorRelay<String>
+        let scheduleTimeRelay: BehaviorRelay<String>
+        let scheduleTitleRelay: BehaviorRelay<String>
     }
     
     struct Output {
-        
+        let dataSaved: PublishRelay<Void>
+    }
+    
+    private var scheduleTime: String?
+    private var scheduleTitle: String?
+    private var selectedDate: String?
+    
+    private var isKeyboardVisible: Bool = false
+    
+    private let dataSaved = PublishRelay<Void>()
+    
+    init(type: AlertTypes) {
+        switch type {
+        case .newSchedule(date: let date):
+            selectedDate = date.formattedDate()
+        case .editSchedule(date: let date):
+            selectedDate = date.formattedDate()
+        case .newDiary, .editDiary, .editMyPage: break
+        }
     }
     
     func transform(input: Input) -> Output {
@@ -34,7 +55,69 @@ final class LovechiveAlertViewModel: ViewModelType {
             }
             .disposed(by: disposeBag)
         
-        return Output()
+        input.activeButtonTapped
+            .withUnretained(self)
+            .compactMap { owner, _ -> ScheduleDataModel? in
+                guard let title = owner.scheduleTitle, let date = owner.scheduleTime,
+                      let selectDate = date.formattedStringToDate(),
+                      !title.isEmpty
+                else {
+                    owner.alert.showAlert(.alert)
+                    return nil
+                }
+                
+                return owner.mappingScheduleData(title: title, date: selectDate)
+            }
+            .flatMap { [weak self] data -> Signal<Void> in
+                guard let self else {
+                    return .empty()
+                }
+                return self.saveScheduleData(data).asSignal(onErrorSignalWith: .empty())
+            }
+            .asSignal(onErrorSignalWith: .empty())
+            .emit { [weak self] _ in
+                self?.dataSaved.accept(())
+                self?.dismissAlertView()
+            }
+            .disposed(by: disposeBag)
+        
+        input.scheduleTimeRelay
+            .withUnretained(self)
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { owner, text in
+                let selectDate = owner.selectedDate ?? ""
+                let date = selectDate + " " + text
+                owner.scheduleTime = date
+            }
+            .disposed(by: disposeBag)
+        
+        input.scheduleTitleRelay
+            .withUnretained(self)
+            .asDriver(onErrorDriveWith: .empty())
+            .drive { owner, text in
+                owner.scheduleTitle = text
+            }
+            .disposed(by: disposeBag)
+        
+        NotificationCenter.default.rx.notification(UIResponder.keyboardWillShowNotification)
+            .map { _ in true }
+            .asSignal(onErrorSignalWith: .empty())
+            .withUnretained(self)
+            .emit { owner, isShow in
+                owner.showKeyboard(isShow)
+            }
+            .disposed(by: disposeBag)
+
+        NotificationCenter.default.rx.notification(UIResponder.keyboardWillHideNotification)
+            .map { _ in false }
+            .asSignal(onErrorSignalWith: .empty())
+            .withUnretained(self)
+            .emit { owner, isHide in
+                owner.showKeyboard(isHide)
+            }
+            .disposed(by: disposeBag)
+        
+        return Output(dataSaved: dataSaved)
     }
     
     private func dismissAlertView() {
@@ -47,5 +130,27 @@ final class LovechiveAlertViewModel: ViewModelType {
             alert.view.removeFromSuperview()
             alert.removeFromParent()
         }
+    }
+    
+    private func showKeyboard(_ isTure: Bool) {
+        guard let topView = AppHelpers.getTopViewController() as? MainViewController,
+              let alert = topView.children.last as? LovechiveAlertViewController
+        else { return }
+        
+        if isTure && (alert.alertView.frame.origin.y < 300) {
+            alert.alertView.frame.origin.y = alert.alertView.frame.origin.y
+        } else if isTure && (alert.alertView.frame.origin.y > 300) {
+            alert.alertView.frame.origin.y -= 100
+        } else if !isTure {
+            alert.alertView.frame.origin.y += 100
+        }
+    }
+    
+    private func mappingScheduleData(title: String, date: Date) -> ScheduleDataModel {
+        return ScheduleDataModel(id: UUID().uuidString, title: title, coupleId: umd.coupleId, date: date, createdBy: umd.userId)
+    }
+    
+    private func saveScheduleData(_ data: ScheduleDataModel) -> Single<Void> {
+        return FirestoreManager.shared.saveToFirestore(data, type: .schedule(id: data.id))
     }
 }

--- a/Lovechive/Lovechive/Source/ViewModel/LovechiveAlertViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/LovechiveAlertViewModel.swift
@@ -1,0 +1,51 @@
+//
+//  LovechiveAlertViewModel.swift
+//  Lovechive
+//
+//  Created by 장상경 on 3/12/25.
+//
+
+import UIKit
+import RxSwift
+import RxCocoa
+
+final class LovechiveAlertViewModel: ViewModelType {
+    
+    private var disposeBag = DisposeBag()
+    
+    struct Input {
+        let cancelButtonTapped: ControlEvent<Void>
+        let activeButtonTapped: ControlEvent<Void>
+//        let scheduleTimeRelay: BehaviorRelay<Date>
+//        let scheduleTitleRelay: BehaviorRelay<String>
+    }
+    
+    struct Output {
+        
+    }
+    
+    func transform(input: Input) -> Output {
+        
+        input.cancelButtonTapped
+            .withUnretained(self)
+            .asSignal(onErrorSignalWith: .empty())
+            .emit { owner, _ in
+                owner.dismissAlertView()
+            }
+            .disposed(by: disposeBag)
+        
+        return Output()
+    }
+    
+    private func dismissAlertView() {
+        guard let topView = AppHelpers.getTopViewController() as? MainViewController,
+              let alert = topView.children.last as? LovechiveAlertViewController
+        else { return }
+        
+        alert.dismissSelf {
+            alert.view.snp.removeConstraints()
+            alert.view.removeFromSuperview()
+            alert.removeFromParent()
+        }
+    }
+}

--- a/Lovechive/Lovechive/Source/ViewModel/LovechiveAlertViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/LovechiveAlertViewModel.swift
@@ -39,9 +39,9 @@ final class LovechiveAlertViewModel: ViewModelType {
     init(type: AlertTypes) {
         switch type {
         case .newSchedule(date: let date):
-            selectedDate = date.formattedDate()
+            selectedDate = date.formattedDateToString(.yearMonthDay)
         case .editSchedule(data: let data):
-            selectedDate = data.date.formattedDate()
+            selectedDate = data.date.formattedDateToString(.yearMonthDay)
             dataId = data.id
         case .newDiary, .editDiary, .editMyPage: break
         }

--- a/Lovechive/Lovechive/Source/ViewModel/LovechiveAlertViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/LovechiveAlertViewModel.swift
@@ -30,6 +30,7 @@ final class LovechiveAlertViewModel: ViewModelType {
     private var scheduleTime: String?
     private var scheduleTitle: String?
     private var selectedDate: String?
+    private var dataId: String?
     
     private var isKeyboardVisible: Bool = false
     
@@ -39,8 +40,9 @@ final class LovechiveAlertViewModel: ViewModelType {
         switch type {
         case .newSchedule(date: let date):
             selectedDate = date.formattedDate()
-        case .editSchedule(date: let date):
-            selectedDate = date.formattedDate()
+        case .editSchedule(data: let data):
+            selectedDate = data.date.formattedDate()
+            dataId = data.id
         case .newDiary, .editDiary, .editMyPage: break
         }
     }
@@ -147,7 +149,8 @@ final class LovechiveAlertViewModel: ViewModelType {
     }
     
     private func mappingScheduleData(title: String, date: Date) -> ScheduleDataModel {
-        return ScheduleDataModel(id: UUID().uuidString, title: title, coupleId: umd.coupleId, date: date, createdBy: umd.userId)
+        let id = dataId ?? UUID().uuidString
+        return ScheduleDataModel(id: id, title: title, coupleId: umd.coupleId, date: date, createdBy: umd.userId)
     }
     
     private func saveScheduleData(_ data: ScheduleDataModel) -> Single<Void> {

--- a/Lovechive/Lovechive/Source/ViewModel/MainPageViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/MainPageViewModel.swift
@@ -18,14 +18,14 @@ final class MainPageViewModel: ViewModelType {
     }
     
     struct Output {
-        let sections: BehaviorRelay<[PlanTableViewSection]>
+        let sections: BehaviorRelay<[ScheduleModelSection]>
         let latestDiaryRelay: PublishRelay<DiaryDataModel>
         let dDayRelay: PublishRelay<CoupleDataModel>
     }
     
     private var disposeBag = DisposeBag()
     
-    private let sections = BehaviorRelay<[PlanTableViewSection]>(value: [])
+    private let sections = BehaviorRelay<[ScheduleModelSection]>(value: [])
     private let latestDiaryRelay = PublishRelay<DiaryDataModel>()
     private let dDayRelay = PublishRelay<CoupleDataModel>()
     
@@ -36,7 +36,7 @@ final class MainPageViewModel: ViewModelType {
                 owner.fetchData(type: .schedule(id: ""))
             }
             .map { [weak self] data in
-                guard let self else { return PlanTableViewSection.init(items: []) }
+                guard let self else { return ScheduleModelSection.init(items: []) }
                 return self.mappingQueryDataToSectionData(data)
             }
             .asDriver(onErrorDriveWith: .empty())
@@ -93,7 +93,7 @@ final class MainPageViewModel: ViewModelType {
     /// Query 데이터를 PlanTableViewSection 타입으로 변환하는 메소드
     /// - Parameter data: Query 데이터
     /// - Returns: 변환된 PlanTableViewSection 데이터
-    private func mappingQueryDataToSectionData(_ data: [QueryDocumentSnapshot]) -> PlanTableViewSection {
+    private func mappingQueryDataToSectionData(_ data: [QueryDocumentSnapshot]) -> ScheduleModelSection {
         let filteredData = data.filter {
             let date = ($0.data()[AppConfig.SchedulesModel.date] as? Timestamp)?.dateValue() ?? Date()
             
@@ -112,7 +112,7 @@ final class MainPageViewModel: ViewModelType {
             $0.date < $1.date
         }).prefix(3))
         
-        let section = PlanTableViewSection(items: sortedData)
+        let section = ScheduleModelSection(items: sortedData)
         
         return section
     }

--- a/Lovechive/Lovechive/Source/ViewModel/MainViewModel.swift
+++ b/Lovechive/Lovechive/Source/ViewModel/MainViewModel.swift
@@ -17,12 +17,10 @@ final class MainViewModel: ViewModelType {
         let secondButtonTapped: ControlEvent<Void>
         let thirdButtonTapped: ControlEvent<Void>
         let forthButtonTapped: ControlEvent<Void>
-        let changedPage: PublishRelay<Int>
     }
     
     struct Output {
         let changedCurretPage: PublishRelay<TabBarButtonState>
-        let scrollToPage: PublishRelay<TabBarButtonState>
     }
     
     private var disposeBag = DisposeBag()
@@ -59,15 +57,6 @@ final class MainViewModel: ViewModelType {
                 owner.changedCurretPage.accept(.setting)
             }.disposed(by: disposeBag)
         
-        input.changedPage
-            .asSignal(onErrorSignalWith: .empty())
-            .withUnretained(self)
-            .emit { owner, index in
-                let state = TabBarButtonState.allCases[index]
-                owner.scrollToPage.accept(state)
-            }.disposed(by: disposeBag)
-        
-        return Output(changedCurretPage: changedCurretPage,
-                      scrollToPage: scrollToPage)
+        return Output(changedCurretPage: changedCurretPage)
     }
 }


### PR DESCRIPTION
이슈 번호: close #5 

## 요약
- 2번 탭, 캘린더 뷰 UI 구현

## 작업 상세 내용
캘린더뷰 UI를 구현하고, 서버와 연동하여 데이터를 추가/삭제/수정 할 수 있음.

미구현 기능:
1. 스크롤 기능 -> 터치 이슈 탓에 일단 빼고 구현

## 스크린샷
![Simulator Screenshot - iPhone 16 - 2025-03-17 at 13 58 44](https://github.com/user-attachments/assets/f12191f7-a744-4904-ad2d-a961027015e8)
